### PR TITLE
compare original gen192 pipeline configs with new ones

### DIFF
--- a/configs/p000_base-abcd_perturb-ccs_step-structural-masking_conn-afni_nuisance-true.yml
+++ b/configs/p000_base-abcd_perturb-ccs_step-structural-masking_conn-afni_nuisance-true.yml
@@ -261,6 +261,7 @@ nuisance_corrections:
     - true
     space: native
 pipeline_setup:
+  freesurfer_dir: /ocean/projects/med220004p/trogers1/many_pipelines/freesurfer/outputs/ABCD_all_subjects
   Amazon-AWS:
     aws_output_bucket_credentials: null
     s3_encryption: false
@@ -290,6 +291,7 @@ pipeline_setup:
     write_debugging_outputs: false
     write_func_outputs: false
   pipeline_name: p000_base-abcd_perturb-ccs_step-structural-masking_conn-afni_nuisance-true
+  desired_orientation: RPI
   system_config:
     FSLDIR: FSLDIR
     fail_fast: false
@@ -311,7 +313,7 @@ pipeline_setup:
     random_seed: null
   working_directory:
     path: /outputs/working
-    remove_working_dir: true
+    remove_working_dir: false
 post_processing:
   spatial_smoothing:
     fwhm:
@@ -405,12 +407,10 @@ registration_workflows:
       FSL-FNIRT:
         FNIRT_T1w_brain_template: null
         FNIRT_T1w_template: null
-        T1w_template_res-2: /opt/dcan-tools/pipeline/global/templates/MNI152_T1_2mm.nii.gz
         fnirt_config: T1_2_MNI152_2mm
         identity_matrix: $FSLDIR/etc/flirtsch/ident.mat
         interpolation: sinc
         ref_mask: $FSLDIR/data/standard/MNI152_T1_${resolution_for_anat}_brain_mask_dil.nii.gz
-        ref_mask_res-2: /opt/dcan-tools/pipeline/global/templates/MNI152_T1_2mm_brain_mask_dil.nii.gz
         ref_resolution: 2mm
       using:
       - ANTS
@@ -501,8 +501,6 @@ registration_workflows:
           func_reg_input_volume: 0
         input:
         - Selected_Functional_Volume
-        reg_with_skull: true
-      input: brain
       interpolation: spline
       run: true
       using: FSL
@@ -593,7 +591,7 @@ surface_analysis:
   freesurfer:
     ingress_reconall: true
     reconall_args: null
-    run_reconall: true
+    run_reconall: false
   post_freesurfer:
     fmri_res: 2
     freesurfer_labels: /opt/dcan-tools/pipeline/global/config/FreeSurferAllLut.txt
@@ -611,11 +609,11 @@ surface_analysis:
     run: true
     surface_parcellation_template: /cpac_templates/Schaefer2018_200Parcels_17Networks_order.dlabel.nii
 timeseries_extraction:
-  connectivity_matrix:
-    measure:
-    - Pearson
-    using:
-    - AFNI
+#  connectivity_matrix:
+#    measure:
+#    - Pearson
+#    using:
+#    - Nilearn
   realignment: ROI_to_func
   run: true
   tse_roi_paths:

--- a/configs/p001_base-abcd_perturb-ccs_step-structural-masking_conn-afni_nuisance-false.yml
+++ b/configs/p001_base-abcd_perturb-ccs_step-structural-masking_conn-afni_nuisance-false.yml
@@ -261,6 +261,7 @@ nuisance_corrections:
     - false
     space: native
 pipeline_setup:
+  freesurfer_dir: /ocean/projects/med220004p/trogers1/many_pipelines/freesurfer/outputs/ABCD_all_subjects
   Amazon-AWS:
     aws_output_bucket_credentials: null
     s3_encryption: false
@@ -311,7 +312,7 @@ pipeline_setup:
     random_seed: null
   working_directory:
     path: /outputs/working
-    remove_working_dir: true
+    remove_working_dir: false
 post_processing:
   spatial_smoothing:
     fwhm:
@@ -405,12 +406,10 @@ registration_workflows:
       FSL-FNIRT:
         FNIRT_T1w_brain_template: null
         FNIRT_T1w_template: null
-        T1w_template_res-2: /opt/dcan-tools/pipeline/global/templates/MNI152_T1_2mm.nii.gz
         fnirt_config: T1_2_MNI152_2mm
         identity_matrix: $FSLDIR/etc/flirtsch/ident.mat
         interpolation: sinc
         ref_mask: $FSLDIR/data/standard/MNI152_T1_${resolution_for_anat}_brain_mask_dil.nii.gz
-        ref_mask_res-2: /opt/dcan-tools/pipeline/global/templates/MNI152_T1_2mm_brain_mask_dil.nii.gz
         ref_resolution: 2mm
       using:
       - ANTS
@@ -501,8 +500,6 @@ registration_workflows:
           func_reg_input_volume: 0
         input:
         - Selected_Functional_Volume
-        reg_with_skull: true
-      input: brain
       interpolation: spline
       run: true
       using: FSL
@@ -593,7 +590,7 @@ surface_analysis:
   freesurfer:
     ingress_reconall: true
     reconall_args: null
-    run_reconall: true
+    run_reconall: false
   post_freesurfer:
     fmri_res: 2
     freesurfer_labels: /opt/dcan-tools/pipeline/global/config/FreeSurferAllLut.txt
@@ -611,11 +608,6 @@ surface_analysis:
     run: true
     surface_parcellation_template: /cpac_templates/Schaefer2018_200Parcels_17Networks_order.dlabel.nii
 timeseries_extraction:
-  connectivity_matrix:
-    measure:
-    - Pearson
-    using:
-    - AFNI
   realignment: ROI_to_func
   run: true
   tse_roi_paths:

--- a/configs/p002_base-abcd_perturb-ccs_step-structural-masking_conn-nilearn_nuisance-true.yml
+++ b/configs/p002_base-abcd_perturb-ccs_step-structural-masking_conn-nilearn_nuisance-true.yml
@@ -261,6 +261,7 @@ nuisance_corrections:
     - true
     space: native
 pipeline_setup:
+  freesurfer_dir: /ocean/projects/med220004p/trogers1/many_pipelines/freesurfer/outputs/ABCD_all_subjects
   Amazon-AWS:
     aws_output_bucket_credentials: null
     s3_encryption: false
@@ -311,7 +312,7 @@ pipeline_setup:
     random_seed: null
   working_directory:
     path: /outputs/working
-    remove_working_dir: true
+    remove_working_dir: false
 post_processing:
   spatial_smoothing:
     fwhm:
@@ -405,12 +406,10 @@ registration_workflows:
       FSL-FNIRT:
         FNIRT_T1w_brain_template: null
         FNIRT_T1w_template: null
-        T1w_template_res-2: /opt/dcan-tools/pipeline/global/templates/MNI152_T1_2mm.nii.gz
         fnirt_config: T1_2_MNI152_2mm
         identity_matrix: $FSLDIR/etc/flirtsch/ident.mat
         interpolation: sinc
         ref_mask: $FSLDIR/data/standard/MNI152_T1_${resolution_for_anat}_brain_mask_dil.nii.gz
-        ref_mask_res-2: /opt/dcan-tools/pipeline/global/templates/MNI152_T1_2mm_brain_mask_dil.nii.gz
         ref_resolution: 2mm
       using:
       - ANTS
@@ -501,8 +500,6 @@ registration_workflows:
           func_reg_input_volume: 0
         input:
         - Selected_Functional_Volume
-        reg_with_skull: true
-      input: brain
       interpolation: spline
       run: true
       using: FSL
@@ -593,7 +590,7 @@ surface_analysis:
   freesurfer:
     ingress_reconall: true
     reconall_args: null
-    run_reconall: true
+    run_reconall: false
   post_freesurfer:
     fmri_res: 2
     freesurfer_labels: /opt/dcan-tools/pipeline/global/config/FreeSurferAllLut.txt
@@ -611,11 +608,6 @@ surface_analysis:
     run: true
     surface_parcellation_template: /cpac_templates/Schaefer2018_200Parcels_17Networks_order.dlabel.nii
 timeseries_extraction:
-  connectivity_matrix:
-    measure:
-    - Pearson
-    using:
-    - Nilearn
   realignment: ROI_to_func
   run: true
   tse_roi_paths:

--- a/configs/p003_base-abcd_perturb-ccs_step-structural-masking_conn-nilearn_nuisance-false.yml
+++ b/configs/p003_base-abcd_perturb-ccs_step-structural-masking_conn-nilearn_nuisance-false.yml
@@ -261,6 +261,7 @@ nuisance_corrections:
     - false
     space: native
 pipeline_setup:
+  freesurfer_dir: /ocean/projects/med220004p/trogers1/many_pipelines/freesurfer/outputs/ABCD_all_subjects
   Amazon-AWS:
     aws_output_bucket_credentials: null
     s3_encryption: false
@@ -311,7 +312,7 @@ pipeline_setup:
     random_seed: null
   working_directory:
     path: /outputs/working
-    remove_working_dir: true
+    remove_working_dir: false
 post_processing:
   spatial_smoothing:
     fwhm:
@@ -405,12 +406,10 @@ registration_workflows:
       FSL-FNIRT:
         FNIRT_T1w_brain_template: null
         FNIRT_T1w_template: null
-        T1w_template_res-2: /opt/dcan-tools/pipeline/global/templates/MNI152_T1_2mm.nii.gz
         fnirt_config: T1_2_MNI152_2mm
         identity_matrix: $FSLDIR/etc/flirtsch/ident.mat
         interpolation: sinc
         ref_mask: $FSLDIR/data/standard/MNI152_T1_${resolution_for_anat}_brain_mask_dil.nii.gz
-        ref_mask_res-2: /opt/dcan-tools/pipeline/global/templates/MNI152_T1_2mm_brain_mask_dil.nii.gz
         ref_resolution: 2mm
       using:
       - ANTS
@@ -501,8 +500,6 @@ registration_workflows:
           func_reg_input_volume: 0
         input:
         - Selected_Functional_Volume
-        reg_with_skull: true
-      input: brain
       interpolation: spline
       run: true
       using: FSL
@@ -593,7 +590,7 @@ surface_analysis:
   freesurfer:
     ingress_reconall: true
     reconall_args: null
-    run_reconall: true
+    run_reconall: false
   post_freesurfer:
     fmri_res: 2
     freesurfer_labels: /opt/dcan-tools/pipeline/global/config/FreeSurferAllLut.txt
@@ -611,11 +608,6 @@ surface_analysis:
     run: true
     surface_parcellation_template: /cpac_templates/Schaefer2018_200Parcels_17Networks_order.dlabel.nii
 timeseries_extraction:
-  connectivity_matrix:
-    measure:
-    - Pearson
-    using:
-    - Nilearn
   realignment: ROI_to_func
   run: true
   tse_roi_paths:

--- a/configs/p004_base-abcd_perturb-ccs_step-structural-registration_conn-afni_nuisance-true.yml
+++ b/configs/p004_base-abcd_perturb-ccs_step-structural-registration_conn-afni_nuisance-true.yml
@@ -259,6 +259,7 @@ nuisance_corrections:
     - true
     space: native
 pipeline_setup:
+  freesurfer_dir: /ocean/projects/med220004p/trogers1/many_pipelines/freesurfer/outputs/ABCD_all_subjects
   Amazon-AWS:
     aws_output_bucket_credentials: null
     s3_encryption: false
@@ -309,7 +310,7 @@ pipeline_setup:
     random_seed: null
   working_directory:
     path: /outputs/working
-    remove_working_dir: true
+    remove_working_dir: false
 post_processing:
   spatial_smoothing:
     fwhm:
@@ -398,12 +399,10 @@ registration_workflows:
       FSL-FNIRT:
         FNIRT_T1w_brain_template: null
         FNIRT_T1w_template: null
-        T1w_template_res-2: $FSLDIR/data/standard/MNI152_T1_2mm.nii.gz
         fnirt_config: T1_2_MNI152_2mm
         identity_matrix: $FSLDIR/etc/flirtsch/ident.mat
         interpolation: trilinear
         ref_mask: $FSLDIR/data/standard/MNI152_T1_${resolution_for_anat}_brain_mask_dil.nii.gz
-        ref_mask_res-2: $FSLDIR/data/standard/MNI152_T1_2mm_brain_mask_dil.nii.gz
         ref_resolution: 2mm
       using:
       - FSL
@@ -494,8 +493,6 @@ registration_workflows:
           func_reg_input_volume: 0
         input:
         - Selected_Functional_Volume
-        reg_with_skull: true
-      input: brain
       interpolation: spline
       run: true
       using: FSL
@@ -586,7 +583,7 @@ surface_analysis:
   freesurfer:
     ingress_reconall: true
     reconall_args: null
-    run_reconall: true
+    run_reconall: false
   post_freesurfer:
     fmri_res: 2
     freesurfer_labels: /opt/dcan-tools/pipeline/global/config/FreeSurferAllLut.txt
@@ -604,11 +601,6 @@ surface_analysis:
     run: true
     surface_parcellation_template: /cpac_templates/Schaefer2018_200Parcels_17Networks_order.dlabel.nii
 timeseries_extraction:
-  connectivity_matrix:
-    measure:
-    - Pearson
-    using:
-    - AFNI
   realignment: ROI_to_func
   run: true
   tse_roi_paths:

--- a/configs/p005_base-abcd_perturb-ccs_step-structural-registration_conn-afni_nuisance-false.yml
+++ b/configs/p005_base-abcd_perturb-ccs_step-structural-registration_conn-afni_nuisance-false.yml
@@ -259,6 +259,7 @@ nuisance_corrections:
     - false
     space: native
 pipeline_setup:
+  freesurfer_dir: /ocean/projects/med220004p/trogers1/many_pipelines/freesurfer/outputs/ABCD_all_subjects
   Amazon-AWS:
     aws_output_bucket_credentials: null
     s3_encryption: false
@@ -309,7 +310,7 @@ pipeline_setup:
     random_seed: null
   working_directory:
     path: /outputs/working
-    remove_working_dir: true
+    remove_working_dir: false
 post_processing:
   spatial_smoothing:
     fwhm:
@@ -398,12 +399,10 @@ registration_workflows:
       FSL-FNIRT:
         FNIRT_T1w_brain_template: null
         FNIRT_T1w_template: null
-        T1w_template_res-2: $FSLDIR/data/standard/MNI152_T1_2mm.nii.gz
         fnirt_config: T1_2_MNI152_2mm
         identity_matrix: $FSLDIR/etc/flirtsch/ident.mat
         interpolation: trilinear
         ref_mask: $FSLDIR/data/standard/MNI152_T1_${resolution_for_anat}_brain_mask_dil.nii.gz
-        ref_mask_res-2: $FSLDIR/data/standard/MNI152_T1_2mm_brain_mask_dil.nii.gz
         ref_resolution: 2mm
       using:
       - FSL
@@ -494,8 +493,6 @@ registration_workflows:
           func_reg_input_volume: 0
         input:
         - Selected_Functional_Volume
-        reg_with_skull: true
-      input: brain
       interpolation: spline
       run: true
       using: FSL
@@ -586,7 +583,7 @@ surface_analysis:
   freesurfer:
     ingress_reconall: true
     reconall_args: null
-    run_reconall: true
+    run_reconall: false
   post_freesurfer:
     fmri_res: 2
     freesurfer_labels: /opt/dcan-tools/pipeline/global/config/FreeSurferAllLut.txt
@@ -604,11 +601,6 @@ surface_analysis:
     run: true
     surface_parcellation_template: /cpac_templates/Schaefer2018_200Parcels_17Networks_order.dlabel.nii
 timeseries_extraction:
-  connectivity_matrix:
-    measure:
-    - Pearson
-    using:
-    - AFNI
   realignment: ROI_to_func
   run: true
   tse_roi_paths:

--- a/configs/p006_base-abcd_perturb-ccs_step-structural-registration_conn-nilearn_nuisance-true.yml
+++ b/configs/p006_base-abcd_perturb-ccs_step-structural-registration_conn-nilearn_nuisance-true.yml
@@ -259,6 +259,7 @@ nuisance_corrections:
     - true
     space: native
 pipeline_setup:
+  freesurfer_dir: /ocean/projects/med220004p/trogers1/many_pipelines/freesurfer/outputs/ABCD_all_subjects
   Amazon-AWS:
     aws_output_bucket_credentials: null
     s3_encryption: false
@@ -309,7 +310,7 @@ pipeline_setup:
     random_seed: null
   working_directory:
     path: /outputs/working
-    remove_working_dir: true
+    remove_working_dir: false
 post_processing:
   spatial_smoothing:
     fwhm:
@@ -398,12 +399,10 @@ registration_workflows:
       FSL-FNIRT:
         FNIRT_T1w_brain_template: null
         FNIRT_T1w_template: null
-        T1w_template_res-2: $FSLDIR/data/standard/MNI152_T1_2mm.nii.gz
         fnirt_config: T1_2_MNI152_2mm
         identity_matrix: $FSLDIR/etc/flirtsch/ident.mat
         interpolation: trilinear
         ref_mask: $FSLDIR/data/standard/MNI152_T1_${resolution_for_anat}_brain_mask_dil.nii.gz
-        ref_mask_res-2: $FSLDIR/data/standard/MNI152_T1_2mm_brain_mask_dil.nii.gz
         ref_resolution: 2mm
       using:
       - FSL
@@ -494,8 +493,6 @@ registration_workflows:
           func_reg_input_volume: 0
         input:
         - Selected_Functional_Volume
-        reg_with_skull: true
-      input: brain
       interpolation: spline
       run: true
       using: FSL
@@ -586,7 +583,7 @@ surface_analysis:
   freesurfer:
     ingress_reconall: true
     reconall_args: null
-    run_reconall: true
+    run_reconall: false
   post_freesurfer:
     fmri_res: 2
     freesurfer_labels: /opt/dcan-tools/pipeline/global/config/FreeSurferAllLut.txt
@@ -604,11 +601,6 @@ surface_analysis:
     run: true
     surface_parcellation_template: /cpac_templates/Schaefer2018_200Parcels_17Networks_order.dlabel.nii
 timeseries_extraction:
-  connectivity_matrix:
-    measure:
-    - Pearson
-    using:
-    - Nilearn
   realignment: ROI_to_func
   run: true
   tse_roi_paths:

--- a/configs/p007_base-abcd_perturb-ccs_step-structural-registration_conn-nilearn_nuisance-false.yml
+++ b/configs/p007_base-abcd_perturb-ccs_step-structural-registration_conn-nilearn_nuisance-false.yml
@@ -259,6 +259,7 @@ nuisance_corrections:
     - false
     space: native
 pipeline_setup:
+  freesurfer_dir: /ocean/projects/med220004p/trogers1/many_pipelines/freesurfer/outputs/ABCD_all_subjects
   Amazon-AWS:
     aws_output_bucket_credentials: null
     s3_encryption: false
@@ -309,7 +310,7 @@ pipeline_setup:
     random_seed: null
   working_directory:
     path: /outputs/working
-    remove_working_dir: true
+    remove_working_dir: false
 post_processing:
   spatial_smoothing:
     fwhm:
@@ -398,12 +399,10 @@ registration_workflows:
       FSL-FNIRT:
         FNIRT_T1w_brain_template: null
         FNIRT_T1w_template: null
-        T1w_template_res-2: $FSLDIR/data/standard/MNI152_T1_2mm.nii.gz
         fnirt_config: T1_2_MNI152_2mm
         identity_matrix: $FSLDIR/etc/flirtsch/ident.mat
         interpolation: trilinear
         ref_mask: $FSLDIR/data/standard/MNI152_T1_${resolution_for_anat}_brain_mask_dil.nii.gz
-        ref_mask_res-2: $FSLDIR/data/standard/MNI152_T1_2mm_brain_mask_dil.nii.gz
         ref_resolution: 2mm
       using:
       - FSL
@@ -494,8 +493,6 @@ registration_workflows:
           func_reg_input_volume: 0
         input:
         - Selected_Functional_Volume
-        reg_with_skull: true
-      input: brain
       interpolation: spline
       run: true
       using: FSL
@@ -586,7 +583,7 @@ surface_analysis:
   freesurfer:
     ingress_reconall: true
     reconall_args: null
-    run_reconall: true
+    run_reconall: false
   post_freesurfer:
     fmri_res: 2
     freesurfer_labels: /opt/dcan-tools/pipeline/global/config/FreeSurferAllLut.txt

--- a/configs/p008_base-abcd_perturb-ccs_step-functional-masking_conn-afni_nuisance-true.yml
+++ b/configs/p008_base-abcd_perturb-ccs_step-functional-masking_conn-afni_nuisance-true.yml
@@ -259,6 +259,7 @@ nuisance_corrections:
     - true
     space: native
 pipeline_setup:
+  freesurfer_dir: /ocean/projects/med220004p/trogers1/many_pipelines/freesurfer/outputs/ABCD_all_subjects
   Amazon-AWS:
     aws_output_bucket_credentials: null
     s3_encryption: false
@@ -309,7 +310,7 @@ pipeline_setup:
     random_seed: null
   working_directory:
     path: /outputs/working
-    remove_working_dir: true
+    remove_working_dir: false
 post_processing:
   spatial_smoothing:
     fwhm:
@@ -403,12 +404,10 @@ registration_workflows:
       FSL-FNIRT:
         FNIRT_T1w_brain_template: null
         FNIRT_T1w_template: null
-        T1w_template_res-2: /opt/dcan-tools/pipeline/global/templates/MNI152_T1_2mm.nii.gz
         fnirt_config: T1_2_MNI152_2mm
         identity_matrix: $FSLDIR/etc/flirtsch/ident.mat
         interpolation: sinc
         ref_mask: $FSLDIR/data/standard/MNI152_T1_${resolution_for_anat}_brain_mask_dil.nii.gz
-        ref_mask_res-2: /opt/dcan-tools/pipeline/global/templates/MNI152_T1_2mm_brain_mask_dil.nii.gz
         ref_resolution: 2mm
       using:
       - ANTS
@@ -499,8 +498,6 @@ registration_workflows:
           func_reg_input_volume: 0
         input:
         - Selected_Functional_Volume
-        reg_with_skull: true
-      input: brain
       interpolation: spline
       run: true
       using: FSL
@@ -591,7 +588,7 @@ surface_analysis:
   freesurfer:
     ingress_reconall: true
     reconall_args: null
-    run_reconall: true
+    run_reconall: false
   post_freesurfer:
     fmri_res: 2
     freesurfer_labels: /opt/dcan-tools/pipeline/global/config/FreeSurferAllLut.txt
@@ -609,11 +606,6 @@ surface_analysis:
     run: true
     surface_parcellation_template: /cpac_templates/Schaefer2018_200Parcels_17Networks_order.dlabel.nii
 timeseries_extraction:
-  connectivity_matrix:
-    measure:
-    - Pearson
-    using:
-    - AFNI
   realignment: ROI_to_func
   run: true
   tse_roi_paths:

--- a/configs/p009_base-abcd_perturb-ccs_step-functional-masking_conn-afni_nuisance-false.yml
+++ b/configs/p009_base-abcd_perturb-ccs_step-functional-masking_conn-afni_nuisance-false.yml
@@ -259,6 +259,7 @@ nuisance_corrections:
     - false
     space: native
 pipeline_setup:
+  freesurfer_dir: /ocean/projects/med220004p/trogers1/many_pipelines/freesurfer/outputs/ABCD_all_subjects
   Amazon-AWS:
     aws_output_bucket_credentials: null
     s3_encryption: false
@@ -309,7 +310,7 @@ pipeline_setup:
     random_seed: null
   working_directory:
     path: /outputs/working
-    remove_working_dir: true
+    remove_working_dir: false
 post_processing:
   spatial_smoothing:
     fwhm:
@@ -403,12 +404,10 @@ registration_workflows:
       FSL-FNIRT:
         FNIRT_T1w_brain_template: null
         FNIRT_T1w_template: null
-        T1w_template_res-2: /opt/dcan-tools/pipeline/global/templates/MNI152_T1_2mm.nii.gz
         fnirt_config: T1_2_MNI152_2mm
         identity_matrix: $FSLDIR/etc/flirtsch/ident.mat
         interpolation: sinc
         ref_mask: $FSLDIR/data/standard/MNI152_T1_${resolution_for_anat}_brain_mask_dil.nii.gz
-        ref_mask_res-2: /opt/dcan-tools/pipeline/global/templates/MNI152_T1_2mm_brain_mask_dil.nii.gz
         ref_resolution: 2mm
       using:
       - ANTS
@@ -499,8 +498,6 @@ registration_workflows:
           func_reg_input_volume: 0
         input:
         - Selected_Functional_Volume
-        reg_with_skull: true
-      input: brain
       interpolation: spline
       run: true
       using: FSL
@@ -591,7 +588,7 @@ surface_analysis:
   freesurfer:
     ingress_reconall: true
     reconall_args: null
-    run_reconall: true
+    run_reconall: false
   post_freesurfer:
     fmri_res: 2
     freesurfer_labels: /opt/dcan-tools/pipeline/global/config/FreeSurferAllLut.txt
@@ -609,11 +606,6 @@ surface_analysis:
     run: true
     surface_parcellation_template: /cpac_templates/Schaefer2018_200Parcels_17Networks_order.dlabel.nii
 timeseries_extraction:
-  connectivity_matrix:
-    measure:
-    - Pearson
-    using:
-    - AFNI
   realignment: ROI_to_func
   run: true
   tse_roi_paths:

--- a/configs/p010_base-abcd_perturb-ccs_step-functional-masking_conn-nilearn_nuisance-true.yml
+++ b/configs/p010_base-abcd_perturb-ccs_step-functional-masking_conn-nilearn_nuisance-true.yml
@@ -259,6 +259,7 @@ nuisance_corrections:
     - true
     space: native
 pipeline_setup:
+  freesurfer_dir: /ocean/projects/med220004p/trogers1/many_pipelines/freesurfer/outputs/ABCD_all_subjects
   Amazon-AWS:
     aws_output_bucket_credentials: null
     s3_encryption: false
@@ -309,7 +310,7 @@ pipeline_setup:
     random_seed: null
   working_directory:
     path: /outputs/working
-    remove_working_dir: true
+    remove_working_dir: false
 post_processing:
   spatial_smoothing:
     fwhm:
@@ -403,12 +404,10 @@ registration_workflows:
       FSL-FNIRT:
         FNIRT_T1w_brain_template: null
         FNIRT_T1w_template: null
-        T1w_template_res-2: /opt/dcan-tools/pipeline/global/templates/MNI152_T1_2mm.nii.gz
         fnirt_config: T1_2_MNI152_2mm
         identity_matrix: $FSLDIR/etc/flirtsch/ident.mat
         interpolation: sinc
         ref_mask: $FSLDIR/data/standard/MNI152_T1_${resolution_for_anat}_brain_mask_dil.nii.gz
-        ref_mask_res-2: /opt/dcan-tools/pipeline/global/templates/MNI152_T1_2mm_brain_mask_dil.nii.gz
         ref_resolution: 2mm
       using:
       - ANTS
@@ -499,8 +498,6 @@ registration_workflows:
           func_reg_input_volume: 0
         input:
         - Selected_Functional_Volume
-        reg_with_skull: true
-      input: brain
       interpolation: spline
       run: true
       using: FSL
@@ -591,7 +588,7 @@ surface_analysis:
   freesurfer:
     ingress_reconall: true
     reconall_args: null
-    run_reconall: true
+    run_reconall: false
   post_freesurfer:
     fmri_res: 2
     freesurfer_labels: /opt/dcan-tools/pipeline/global/config/FreeSurferAllLut.txt
@@ -609,11 +606,6 @@ surface_analysis:
     run: true
     surface_parcellation_template: /cpac_templates/Schaefer2018_200Parcels_17Networks_order.dlabel.nii
 timeseries_extraction:
-  connectivity_matrix:
-    measure:
-    - Pearson
-    using:
-    - Nilearn
   realignment: ROI_to_func
   run: true
   tse_roi_paths:

--- a/configs/p011_base-abcd_perturb-ccs_step-functional-masking_conn-nilearn_nuisance-false.yml
+++ b/configs/p011_base-abcd_perturb-ccs_step-functional-masking_conn-nilearn_nuisance-false.yml
@@ -259,6 +259,7 @@ nuisance_corrections:
     - false
     space: native
 pipeline_setup:
+  freesurfer_dir: /ocean/projects/med220004p/trogers1/many_pipelines/freesurfer/outputs/ABCD_all_subjects
   Amazon-AWS:
     aws_output_bucket_credentials: null
     s3_encryption: false
@@ -309,7 +310,7 @@ pipeline_setup:
     random_seed: null
   working_directory:
     path: /outputs/working
-    remove_working_dir: true
+    remove_working_dir: false
 post_processing:
   spatial_smoothing:
     fwhm:
@@ -403,12 +404,10 @@ registration_workflows:
       FSL-FNIRT:
         FNIRT_T1w_brain_template: null
         FNIRT_T1w_template: null
-        T1w_template_res-2: /opt/dcan-tools/pipeline/global/templates/MNI152_T1_2mm.nii.gz
         fnirt_config: T1_2_MNI152_2mm
         identity_matrix: $FSLDIR/etc/flirtsch/ident.mat
         interpolation: sinc
         ref_mask: $FSLDIR/data/standard/MNI152_T1_${resolution_for_anat}_brain_mask_dil.nii.gz
-        ref_mask_res-2: /opt/dcan-tools/pipeline/global/templates/MNI152_T1_2mm_brain_mask_dil.nii.gz
         ref_resolution: 2mm
       using:
       - ANTS
@@ -499,8 +498,6 @@ registration_workflows:
           func_reg_input_volume: 0
         input:
         - Selected_Functional_Volume
-        reg_with_skull: true
-      input: brain
       interpolation: spline
       run: true
       using: FSL
@@ -591,7 +588,7 @@ surface_analysis:
   freesurfer:
     ingress_reconall: true
     reconall_args: null
-    run_reconall: true
+    run_reconall: false
   post_freesurfer:
     fmri_res: 2
     freesurfer_labels: /opt/dcan-tools/pipeline/global/config/FreeSurferAllLut.txt
@@ -609,11 +606,6 @@ surface_analysis:
     run: true
     surface_parcellation_template: /cpac_templates/Schaefer2018_200Parcels_17Networks_order.dlabel.nii
 timeseries_extraction:
-  connectivity_matrix:
-    measure:
-    - Pearson
-    using:
-    - Nilearn
   realignment: ROI_to_func
   run: true
   tse_roi_paths:

--- a/configs/p012_base-abcd_perturb-ccs_step-functional-registration_conn-afni_nuisance-true.yml
+++ b/configs/p012_base-abcd_perturb-ccs_step-functional-registration_conn-afni_nuisance-true.yml
@@ -122,6 +122,7 @@ functional_preproc:
     - PhaseDiff
     - Blip-FSL-TOPUP
   func_masking:
+    run: true
     Anatomical_Refined:
       anatomical_mask_dilation: false
     FSL-BET:
@@ -146,7 +147,7 @@ functional_preproc:
       bold_ref: null
       brain_mask: $FSLDIR/data/standard/MNI152_T1_${resolution_for_anat}_brain_mask.nii.gz
       brain_probseg: $FSLDIR/data/standard/MNI152_T1_${resolution_for_anat}_brain_mask.nii.gz
-    apply_func_mask_in_native_space: false
+    apply_func_mask_in_native_space: true
     run: true
     using:
     - Anatomical_Resampled
@@ -259,6 +260,7 @@ nuisance_corrections:
     - true
     space: native
 pipeline_setup:
+  freesurfer_dir: /ocean/projects/med220004p/trogers1/many_pipelines/freesurfer/outputs/ABCD_all_subjects
   Amazon-AWS:
     aws_output_bucket_credentials: null
     s3_encryption: false
@@ -309,7 +311,7 @@ pipeline_setup:
     random_seed: null
   working_directory:
     path: /outputs/working
-    remove_working_dir: true
+    remove_working_dir: false
 post_processing:
   spatial_smoothing:
     fwhm:
@@ -403,12 +405,10 @@ registration_workflows:
       FSL-FNIRT:
         FNIRT_T1w_brain_template: null
         FNIRT_T1w_template: null
-        T1w_template_res-2: /opt/dcan-tools/pipeline/global/templates/MNI152_T1_2mm.nii.gz
         fnirt_config: T1_2_MNI152_2mm
         identity_matrix: $FSLDIR/etc/flirtsch/ident.mat
         interpolation: sinc
         ref_mask: $FSLDIR/data/standard/MNI152_T1_${resolution_for_anat}_brain_mask_dil.nii.gz
-        ref_mask_res-2: /opt/dcan-tools/pipeline/global/templates/MNI152_T1_2mm_brain_mask_dil.nii.gz
         ref_resolution: 2mm
       using:
       - ANTS
@@ -499,8 +499,6 @@ registration_workflows:
           func_reg_input_volume: 7
         input:
         - Selected_Functional_Volume
-        reg_with_skull: false
-      input: brain
       interpolation: trilinear
       run: true
       using: FSL
@@ -591,7 +589,7 @@ surface_analysis:
   freesurfer:
     ingress_reconall: true
     reconall_args: null
-    run_reconall: true
+    run_reconall: false
   post_freesurfer:
     fmri_res: 2
     freesurfer_labels: /opt/dcan-tools/pipeline/global/config/FreeSurferAllLut.txt
@@ -609,11 +607,6 @@ surface_analysis:
     run: true
     surface_parcellation_template: /cpac_templates/Schaefer2018_200Parcels_17Networks_order.dlabel.nii
 timeseries_extraction:
-  connectivity_matrix:
-    measure:
-    - Pearson
-    using:
-    - AFNI
   realignment: ROI_to_func
   run: true
   tse_roi_paths:

--- a/configs/p013_base-abcd_perturb-ccs_step-functional-registration_conn-afni_nuisance-false.yml
+++ b/configs/p013_base-abcd_perturb-ccs_step-functional-registration_conn-afni_nuisance-false.yml
@@ -146,7 +146,7 @@ functional_preproc:
       bold_ref: null
       brain_mask: $FSLDIR/data/standard/MNI152_T1_${resolution_for_anat}_brain_mask.nii.gz
       brain_probseg: $FSLDIR/data/standard/MNI152_T1_${resolution_for_anat}_brain_mask.nii.gz
-    apply_func_mask_in_native_space: false
+    apply_func_mask_in_native_space: true
     run: true
     using:
     - Anatomical_Resampled
@@ -259,6 +259,7 @@ nuisance_corrections:
     - false
     space: native
 pipeline_setup:
+  freesurfer_dir: /ocean/projects/med220004p/trogers1/many_pipelines/freesurfer/outputs/ABCD_all_subjects
   Amazon-AWS:
     aws_output_bucket_credentials: null
     s3_encryption: false
@@ -309,7 +310,7 @@ pipeline_setup:
     random_seed: null
   working_directory:
     path: /outputs/working
-    remove_working_dir: true
+    remove_working_dir: false
 post_processing:
   spatial_smoothing:
     fwhm:
@@ -403,12 +404,10 @@ registration_workflows:
       FSL-FNIRT:
         FNIRT_T1w_brain_template: null
         FNIRT_T1w_template: null
-        T1w_template_res-2: /opt/dcan-tools/pipeline/global/templates/MNI152_T1_2mm.nii.gz
         fnirt_config: T1_2_MNI152_2mm
         identity_matrix: $FSLDIR/etc/flirtsch/ident.mat
         interpolation: sinc
         ref_mask: $FSLDIR/data/standard/MNI152_T1_${resolution_for_anat}_brain_mask_dil.nii.gz
-        ref_mask_res-2: /opt/dcan-tools/pipeline/global/templates/MNI152_T1_2mm_brain_mask_dil.nii.gz
         ref_resolution: 2mm
       using:
       - ANTS
@@ -499,8 +498,6 @@ registration_workflows:
           func_reg_input_volume: 7
         input:
         - Selected_Functional_Volume
-        reg_with_skull: false
-      input: brain
       interpolation: trilinear
       run: true
       using: FSL
@@ -591,7 +588,7 @@ surface_analysis:
   freesurfer:
     ingress_reconall: true
     reconall_args: null
-    run_reconall: true
+    run_reconall: false
   post_freesurfer:
     fmri_res: 2
     freesurfer_labels: /opt/dcan-tools/pipeline/global/config/FreeSurferAllLut.txt
@@ -609,11 +606,6 @@ surface_analysis:
     run: true
     surface_parcellation_template: /cpac_templates/Schaefer2018_200Parcels_17Networks_order.dlabel.nii
 timeseries_extraction:
-  connectivity_matrix:
-    measure:
-    - Pearson
-    using:
-    - AFNI
   realignment: ROI_to_func
   run: true
   tse_roi_paths:

--- a/configs/p014_base-abcd_perturb-ccs_step-functional-registration_conn-nilearn_nuisance-true.yml
+++ b/configs/p014_base-abcd_perturb-ccs_step-functional-registration_conn-nilearn_nuisance-true.yml
@@ -146,7 +146,7 @@ functional_preproc:
       bold_ref: null
       brain_mask: $FSLDIR/data/standard/MNI152_T1_${resolution_for_anat}_brain_mask.nii.gz
       brain_probseg: $FSLDIR/data/standard/MNI152_T1_${resolution_for_anat}_brain_mask.nii.gz
-    apply_func_mask_in_native_space: false
+    apply_func_mask_in_native_space: true
     run: true
     using:
     - Anatomical_Resampled
@@ -259,6 +259,7 @@ nuisance_corrections:
     - true
     space: native
 pipeline_setup:
+  freesurfer_dir: /ocean/projects/med220004p/trogers1/many_pipelines/freesurfer/outputs/ABCD_all_subjects
   Amazon-AWS:
     aws_output_bucket_credentials: null
     s3_encryption: false
@@ -309,7 +310,7 @@ pipeline_setup:
     random_seed: null
   working_directory:
     path: /outputs/working
-    remove_working_dir: true
+    remove_working_dir: false
 post_processing:
   spatial_smoothing:
     fwhm:
@@ -403,12 +404,10 @@ registration_workflows:
       FSL-FNIRT:
         FNIRT_T1w_brain_template: null
         FNIRT_T1w_template: null
-        T1w_template_res-2: /opt/dcan-tools/pipeline/global/templates/MNI152_T1_2mm.nii.gz
         fnirt_config: T1_2_MNI152_2mm
         identity_matrix: $FSLDIR/etc/flirtsch/ident.mat
         interpolation: sinc
         ref_mask: $FSLDIR/data/standard/MNI152_T1_${resolution_for_anat}_brain_mask_dil.nii.gz
-        ref_mask_res-2: /opt/dcan-tools/pipeline/global/templates/MNI152_T1_2mm_brain_mask_dil.nii.gz
         ref_resolution: 2mm
       using:
       - ANTS
@@ -499,8 +498,6 @@ registration_workflows:
           func_reg_input_volume: 7
         input:
         - Selected_Functional_Volume
-        reg_with_skull: false
-      input: brain
       interpolation: trilinear
       run: true
       using: FSL
@@ -591,7 +588,7 @@ surface_analysis:
   freesurfer:
     ingress_reconall: true
     reconall_args: null
-    run_reconall: true
+    run_reconall: false
   post_freesurfer:
     fmri_res: 2
     freesurfer_labels: /opt/dcan-tools/pipeline/global/config/FreeSurferAllLut.txt
@@ -609,11 +606,6 @@ surface_analysis:
     run: true
     surface_parcellation_template: /cpac_templates/Schaefer2018_200Parcels_17Networks_order.dlabel.nii
 timeseries_extraction:
-  connectivity_matrix:
-    measure:
-    - Pearson
-    using:
-    - Nilearn
   realignment: ROI_to_func
   run: true
   tse_roi_paths:

--- a/configs/p015_base-abcd_perturb-ccs_step-functional-registration_conn-nilearn_nuisance-false.yml
+++ b/configs/p015_base-abcd_perturb-ccs_step-functional-registration_conn-nilearn_nuisance-false.yml
@@ -146,7 +146,7 @@ functional_preproc:
       bold_ref: null
       brain_mask: $FSLDIR/data/standard/MNI152_T1_${resolution_for_anat}_brain_mask.nii.gz
       brain_probseg: $FSLDIR/data/standard/MNI152_T1_${resolution_for_anat}_brain_mask.nii.gz
-    apply_func_mask_in_native_space: false
+    apply_func_mask_in_native_space: true
     run: true
     using:
     - Anatomical_Resampled
@@ -259,6 +259,7 @@ nuisance_corrections:
     - false
     space: native
 pipeline_setup:
+  freesurfer_dir: /ocean/projects/med220004p/trogers1/many_pipelines/freesurfer/outputs/ABCD_all_subjects
   Amazon-AWS:
     aws_output_bucket_credentials: null
     s3_encryption: false
@@ -309,7 +310,7 @@ pipeline_setup:
     random_seed: null
   working_directory:
     path: /outputs/working
-    remove_working_dir: true
+    remove_working_dir: false
 post_processing:
   spatial_smoothing:
     fwhm:
@@ -403,12 +404,10 @@ registration_workflows:
       FSL-FNIRT:
         FNIRT_T1w_brain_template: null
         FNIRT_T1w_template: null
-        T1w_template_res-2: /opt/dcan-tools/pipeline/global/templates/MNI152_T1_2mm.nii.gz
         fnirt_config: T1_2_MNI152_2mm
         identity_matrix: $FSLDIR/etc/flirtsch/ident.mat
         interpolation: sinc
         ref_mask: $FSLDIR/data/standard/MNI152_T1_${resolution_for_anat}_brain_mask_dil.nii.gz
-        ref_mask_res-2: /opt/dcan-tools/pipeline/global/templates/MNI152_T1_2mm_brain_mask_dil.nii.gz
         ref_resolution: 2mm
       using:
       - ANTS
@@ -499,8 +498,6 @@ registration_workflows:
           func_reg_input_volume: 7
         input:
         - Selected_Functional_Volume
-        reg_with_skull: false
-      input: brain
       interpolation: trilinear
       run: true
       using: FSL
@@ -591,7 +588,7 @@ surface_analysis:
   freesurfer:
     ingress_reconall: true
     reconall_args: null
-    run_reconall: true
+    run_reconall: false
   post_freesurfer:
     fmri_res: 2
     freesurfer_labels: /opt/dcan-tools/pipeline/global/config/FreeSurferAllLut.txt
@@ -609,11 +606,6 @@ surface_analysis:
     run: true
     surface_parcellation_template: /cpac_templates/Schaefer2018_200Parcels_17Networks_order.dlabel.nii
 timeseries_extraction:
-  connectivity_matrix:
-    measure:
-    - Pearson
-    using:
-    - Nilearn
   realignment: ROI_to_func
   run: true
   tse_roi_paths:

--- a/configs/p016_base-abcd_perturb-rbc_step-structural-masking_conn-afni_nuisance-true.yml
+++ b/configs/p016_base-abcd_perturb-rbc_step-structural-masking_conn-afni_nuisance-true.yml
@@ -259,6 +259,7 @@ nuisance_corrections:
     - true
     space: native
 pipeline_setup:
+  freesurfer_dir: /ocean/projects/med220004p/trogers1/many_pipelines/freesurfer/outputs/ABCD_all_subjects
   Amazon-AWS:
     aws_output_bucket_credentials: null
     s3_encryption: false
@@ -309,7 +310,7 @@ pipeline_setup:
     random_seed: null
   working_directory:
     path: /outputs/working
-    remove_working_dir: true
+    remove_working_dir: false
 post_processing:
   spatial_smoothing:
     fwhm:
@@ -403,12 +404,10 @@ registration_workflows:
       FSL-FNIRT:
         FNIRT_T1w_brain_template: null
         FNIRT_T1w_template: null
-        T1w_template_res-2: /opt/dcan-tools/pipeline/global/templates/MNI152_T1_2mm.nii.gz
         fnirt_config: T1_2_MNI152_2mm
         identity_matrix: $FSLDIR/etc/flirtsch/ident.mat
         interpolation: sinc
         ref_mask: $FSLDIR/data/standard/MNI152_T1_${resolution_for_anat}_brain_mask_dil.nii.gz
-        ref_mask_res-2: /opt/dcan-tools/pipeline/global/templates/MNI152_T1_2mm_brain_mask_dil.nii.gz
         ref_resolution: 2mm
       using:
       - ANTS
@@ -499,8 +498,6 @@ registration_workflows:
           func_reg_input_volume: 0
         input:
         - Selected_Functional_Volume
-        reg_with_skull: true
-      input: brain
       interpolation: spline
       run: true
       using: FSL
@@ -591,7 +588,7 @@ surface_analysis:
   freesurfer:
     ingress_reconall: true
     reconall_args: null
-    run_reconall: true
+    run_reconall: false
   post_freesurfer:
     fmri_res: 2
     freesurfer_labels: /opt/dcan-tools/pipeline/global/config/FreeSurferAllLut.txt
@@ -609,11 +606,6 @@ surface_analysis:
     run: true
     surface_parcellation_template: /cpac_templates/Schaefer2018_200Parcels_17Networks_order.dlabel.nii
 timeseries_extraction:
-  connectivity_matrix:
-    measure:
-    - Pearson
-    using:
-    - AFNI
   realignment: ROI_to_func
   run: true
   tse_roi_paths:

--- a/configs/p017_base-abcd_perturb-rbc_step-structural-masking_conn-afni_nuisance-false.yml
+++ b/configs/p017_base-abcd_perturb-rbc_step-structural-masking_conn-afni_nuisance-false.yml
@@ -259,6 +259,7 @@ nuisance_corrections:
     - false
     space: native
 pipeline_setup:
+  freesurfer_dir: /ocean/projects/med220004p/trogers1/many_pipelines/freesurfer/outputs/ABCD_all_subjects
   Amazon-AWS:
     aws_output_bucket_credentials: null
     s3_encryption: false
@@ -309,7 +310,7 @@ pipeline_setup:
     random_seed: null
   working_directory:
     path: /outputs/working
-    remove_working_dir: true
+    remove_working_dir: false
 post_processing:
   spatial_smoothing:
     fwhm:
@@ -403,12 +404,10 @@ registration_workflows:
       FSL-FNIRT:
         FNIRT_T1w_brain_template: null
         FNIRT_T1w_template: null
-        T1w_template_res-2: /opt/dcan-tools/pipeline/global/templates/MNI152_T1_2mm.nii.gz
         fnirt_config: T1_2_MNI152_2mm
         identity_matrix: $FSLDIR/etc/flirtsch/ident.mat
         interpolation: sinc
         ref_mask: $FSLDIR/data/standard/MNI152_T1_${resolution_for_anat}_brain_mask_dil.nii.gz
-        ref_mask_res-2: /opt/dcan-tools/pipeline/global/templates/MNI152_T1_2mm_brain_mask_dil.nii.gz
         ref_resolution: 2mm
       using:
       - ANTS
@@ -499,8 +498,6 @@ registration_workflows:
           func_reg_input_volume: 0
         input:
         - Selected_Functional_Volume
-        reg_with_skull: true
-      input: brain
       interpolation: spline
       run: true
       using: FSL
@@ -591,7 +588,7 @@ surface_analysis:
   freesurfer:
     ingress_reconall: true
     reconall_args: null
-    run_reconall: true
+    run_reconall: false
   post_freesurfer:
     fmri_res: 2
     freesurfer_labels: /opt/dcan-tools/pipeline/global/config/FreeSurferAllLut.txt
@@ -609,11 +606,6 @@ surface_analysis:
     run: true
     surface_parcellation_template: /cpac_templates/Schaefer2018_200Parcels_17Networks_order.dlabel.nii
 timeseries_extraction:
-  connectivity_matrix:
-    measure:
-    - Pearson
-    using:
-    - AFNI
   realignment: ROI_to_func
   run: true
   tse_roi_paths:

--- a/configs/p018_base-abcd_perturb-rbc_step-structural-masking_conn-nilearn_nuisance-true.yml
+++ b/configs/p018_base-abcd_perturb-rbc_step-structural-masking_conn-nilearn_nuisance-true.yml
@@ -259,6 +259,7 @@ nuisance_corrections:
     - true
     space: native
 pipeline_setup:
+  freesurfer_dir: /ocean/projects/med220004p/trogers1/many_pipelines/freesurfer/outputs/ABCD_all_subjects
   Amazon-AWS:
     aws_output_bucket_credentials: null
     s3_encryption: false
@@ -309,7 +310,7 @@ pipeline_setup:
     random_seed: null
   working_directory:
     path: /outputs/working
-    remove_working_dir: true
+    remove_working_dir: false
 post_processing:
   spatial_smoothing:
     fwhm:
@@ -403,12 +404,10 @@ registration_workflows:
       FSL-FNIRT:
         FNIRT_T1w_brain_template: null
         FNIRT_T1w_template: null
-        T1w_template_res-2: /opt/dcan-tools/pipeline/global/templates/MNI152_T1_2mm.nii.gz
         fnirt_config: T1_2_MNI152_2mm
         identity_matrix: $FSLDIR/etc/flirtsch/ident.mat
         interpolation: sinc
         ref_mask: $FSLDIR/data/standard/MNI152_T1_${resolution_for_anat}_brain_mask_dil.nii.gz
-        ref_mask_res-2: /opt/dcan-tools/pipeline/global/templates/MNI152_T1_2mm_brain_mask_dil.nii.gz
         ref_resolution: 2mm
       using:
       - ANTS
@@ -499,8 +498,6 @@ registration_workflows:
           func_reg_input_volume: 0
         input:
         - Selected_Functional_Volume
-        reg_with_skull: true
-      input: brain
       interpolation: spline
       run: true
       using: FSL
@@ -591,7 +588,7 @@ surface_analysis:
   freesurfer:
     ingress_reconall: true
     reconall_args: null
-    run_reconall: true
+    run_reconall: false
   post_freesurfer:
     fmri_res: 2
     freesurfer_labels: /opt/dcan-tools/pipeline/global/config/FreeSurferAllLut.txt
@@ -609,11 +606,6 @@ surface_analysis:
     run: true
     surface_parcellation_template: /cpac_templates/Schaefer2018_200Parcels_17Networks_order.dlabel.nii
 timeseries_extraction:
-  connectivity_matrix:
-    measure:
-    - Pearson
-    using:
-    - Nilearn
   realignment: ROI_to_func
   run: true
   tse_roi_paths:

--- a/configs/p019_base-abcd_perturb-rbc_step-structural-masking_conn-nilearn_nuisance-false.yml
+++ b/configs/p019_base-abcd_perturb-rbc_step-structural-masking_conn-nilearn_nuisance-false.yml
@@ -259,6 +259,7 @@ nuisance_corrections:
     - false
     space: native
 pipeline_setup:
+  freesurfer_dir: /ocean/projects/med220004p/trogers1/many_pipelines/freesurfer/outputs/ABCD_all_subjects
   Amazon-AWS:
     aws_output_bucket_credentials: null
     s3_encryption: false
@@ -309,7 +310,7 @@ pipeline_setup:
     random_seed: null
   working_directory:
     path: /outputs/working
-    remove_working_dir: true
+    remove_working_dir: false
 post_processing:
   spatial_smoothing:
     fwhm:
@@ -403,12 +404,10 @@ registration_workflows:
       FSL-FNIRT:
         FNIRT_T1w_brain_template: null
         FNIRT_T1w_template: null
-        T1w_template_res-2: /opt/dcan-tools/pipeline/global/templates/MNI152_T1_2mm.nii.gz
         fnirt_config: T1_2_MNI152_2mm
         identity_matrix: $FSLDIR/etc/flirtsch/ident.mat
         interpolation: sinc
         ref_mask: $FSLDIR/data/standard/MNI152_T1_${resolution_for_anat}_brain_mask_dil.nii.gz
-        ref_mask_res-2: /opt/dcan-tools/pipeline/global/templates/MNI152_T1_2mm_brain_mask_dil.nii.gz
         ref_resolution: 2mm
       using:
       - ANTS
@@ -499,8 +498,6 @@ registration_workflows:
           func_reg_input_volume: 0
         input:
         - Selected_Functional_Volume
-        reg_with_skull: true
-      input: brain
       interpolation: spline
       run: true
       using: FSL
@@ -591,7 +588,7 @@ surface_analysis:
   freesurfer:
     ingress_reconall: true
     reconall_args: null
-    run_reconall: true
+    run_reconall: false
   post_freesurfer:
     fmri_res: 2
     freesurfer_labels: /opt/dcan-tools/pipeline/global/config/FreeSurferAllLut.txt
@@ -609,11 +606,6 @@ surface_analysis:
     run: true
     surface_parcellation_template: /cpac_templates/Schaefer2018_200Parcels_17Networks_order.dlabel.nii
 timeseries_extraction:
-  connectivity_matrix:
-    measure:
-    - Pearson
-    using:
-    - Nilearn
   realignment: ROI_to_func
   run: true
   tse_roi_paths:

--- a/configs/p020_base-abcd_perturb-rbc_step-structural-registration_conn-afni_nuisance-true.yml
+++ b/configs/p020_base-abcd_perturb-rbc_step-structural-registration_conn-afni_nuisance-true.yml
@@ -259,6 +259,7 @@ nuisance_corrections:
     - true
     space: native
 pipeline_setup:
+  freesurfer_dir: /ocean/projects/med220004p/trogers1/many_pipelines/freesurfer/outputs/ABCD_all_subjects
   Amazon-AWS:
     aws_output_bucket_credentials: null
     s3_encryption: false
@@ -309,7 +310,7 @@ pipeline_setup:
     random_seed: null
   working_directory:
     path: /outputs/working
-    remove_working_dir: true
+    remove_working_dir: false
 post_processing:
   spatial_smoothing:
     fwhm:
@@ -334,7 +335,7 @@ registration_workflows:
     T1w_brain_template_mask: $FSLDIR/data/standard/MNI152_T1_${resolution_for_anat}_brain_mask.nii.gz
     T1w_template: $FSLDIR/data/standard/MNI152_T1_${resolution_for_anat}.nii.gz
     overwrite_transform:
-      run: false
+      run: true
       using: FSL
     reg_with_skull: false
     registration:
@@ -398,12 +399,11 @@ registration_workflows:
       FSL-FNIRT:
         FNIRT_T1w_brain_template: null
         FNIRT_T1w_template: null
-        T1w_template_res-2: null
+        T1w_template_res-2: $FSLDIR/data/standard/MNI152_T1_2mm_brain_mask.nii.gz
         fnirt_config: T1_2_MNI152_2mm
         identity_matrix: $FSLDIR/etc/flirtsch/ident.mat
         interpolation: sinc
         ref_mask: null
-        ref_mask_res-2: null
         ref_resolution: 2mm
       using:
       - ANTS
@@ -494,8 +494,6 @@ registration_workflows:
           func_reg_input_volume: 0
         input:
         - Selected_Functional_Volume
-        reg_with_skull: true
-      input: brain
       interpolation: spline
       run: true
       using: FSL
@@ -586,7 +584,7 @@ surface_analysis:
   freesurfer:
     ingress_reconall: true
     reconall_args: null
-    run_reconall: true
+    run_reconall: false
   post_freesurfer:
     fmri_res: 2
     freesurfer_labels: /opt/dcan-tools/pipeline/global/config/FreeSurferAllLut.txt
@@ -604,11 +602,6 @@ surface_analysis:
     run: true
     surface_parcellation_template: /cpac_templates/Schaefer2018_200Parcels_17Networks_order.dlabel.nii
 timeseries_extraction:
-  connectivity_matrix:
-    measure:
-    - Pearson
-    using:
-    - AFNI
   realignment: ROI_to_func
   run: true
   tse_roi_paths:

--- a/configs/p021_base-abcd_perturb-rbc_step-structural-registration_conn-afni_nuisance-false.yml
+++ b/configs/p021_base-abcd_perturb-rbc_step-structural-registration_conn-afni_nuisance-false.yml
@@ -259,6 +259,7 @@ nuisance_corrections:
     - false
     space: native
 pipeline_setup:
+  freesurfer_dir: /ocean/projects/med220004p/trogers1/many_pipelines/freesurfer/outputs/ABCD_all_subjects
   Amazon-AWS:
     aws_output_bucket_credentials: null
     s3_encryption: false
@@ -309,7 +310,7 @@ pipeline_setup:
     random_seed: null
   working_directory:
     path: /outputs/working
-    remove_working_dir: true
+    remove_working_dir: false
 post_processing:
   spatial_smoothing:
     fwhm:
@@ -334,7 +335,7 @@ registration_workflows:
     T1w_brain_template_mask: $FSLDIR/data/standard/MNI152_T1_${resolution_for_anat}_brain_mask.nii.gz
     T1w_template: $FSLDIR/data/standard/MNI152_T1_${resolution_for_anat}.nii.gz
     overwrite_transform:
-      run: false
+      run: true
       using: FSL
     reg_with_skull: false
     registration:
@@ -398,12 +399,11 @@ registration_workflows:
       FSL-FNIRT:
         FNIRT_T1w_brain_template: null
         FNIRT_T1w_template: null
-        T1w_template_res-2: null
+        T1w_template_res-2: $FSLDIR/data/standard/MNI152_T1_2mm_brain_mask.nii.gz
         fnirt_config: T1_2_MNI152_2mm
         identity_matrix: $FSLDIR/etc/flirtsch/ident.mat
         interpolation: sinc
         ref_mask: null
-        ref_mask_res-2: null
         ref_resolution: 2mm
       using:
       - ANTS
@@ -494,8 +494,6 @@ registration_workflows:
           func_reg_input_volume: 0
         input:
         - Selected_Functional_Volume
-        reg_with_skull: true
-      input: brain
       interpolation: spline
       run: true
       using: FSL
@@ -586,7 +584,7 @@ surface_analysis:
   freesurfer:
     ingress_reconall: true
     reconall_args: null
-    run_reconall: true
+    run_reconall: false
   post_freesurfer:
     fmri_res: 2
     freesurfer_labels: /opt/dcan-tools/pipeline/global/config/FreeSurferAllLut.txt
@@ -604,11 +602,6 @@ surface_analysis:
     run: true
     surface_parcellation_template: /cpac_templates/Schaefer2018_200Parcels_17Networks_order.dlabel.nii
 timeseries_extraction:
-  connectivity_matrix:
-    measure:
-    - Pearson
-    using:
-    - AFNI
   realignment: ROI_to_func
   run: true
   tse_roi_paths:

--- a/configs/p022_base-abcd_perturb-rbc_step-structural-registration_conn-nilearn_nuisance-true.yml
+++ b/configs/p022_base-abcd_perturb-rbc_step-structural-registration_conn-nilearn_nuisance-true.yml
@@ -259,6 +259,7 @@ nuisance_corrections:
     - true
     space: native
 pipeline_setup:
+  freesurfer_dir: /ocean/projects/med220004p/trogers1/many_pipelines/freesurfer/outputs/ABCD_all_subjects
   Amazon-AWS:
     aws_output_bucket_credentials: null
     s3_encryption: false
@@ -309,7 +310,7 @@ pipeline_setup:
     random_seed: null
   working_directory:
     path: /outputs/working
-    remove_working_dir: true
+    remove_working_dir: false
 post_processing:
   spatial_smoothing:
     fwhm:
@@ -334,7 +335,7 @@ registration_workflows:
     T1w_brain_template_mask: $FSLDIR/data/standard/MNI152_T1_${resolution_for_anat}_brain_mask.nii.gz
     T1w_template: $FSLDIR/data/standard/MNI152_T1_${resolution_for_anat}.nii.gz
     overwrite_transform:
-      run: false
+      run: true
       using: FSL
     reg_with_skull: false
     registration:
@@ -398,12 +399,11 @@ registration_workflows:
       FSL-FNIRT:
         FNIRT_T1w_brain_template: null
         FNIRT_T1w_template: null
-        T1w_template_res-2: null
+        T1w_template_res-2: $FSLDIR/data/standard/MNI152_T1_2mm_brain_mask.nii.gz
         fnirt_config: T1_2_MNI152_2mm
         identity_matrix: $FSLDIR/etc/flirtsch/ident.mat
         interpolation: sinc
         ref_mask: null
-        ref_mask_res-2: null
         ref_resolution: 2mm
       using:
       - ANTS
@@ -494,8 +494,6 @@ registration_workflows:
           func_reg_input_volume: 0
         input:
         - Selected_Functional_Volume
-        reg_with_skull: true
-      input: brain
       interpolation: spline
       run: true
       using: FSL
@@ -586,7 +584,7 @@ surface_analysis:
   freesurfer:
     ingress_reconall: true
     reconall_args: null
-    run_reconall: true
+    run_reconall: false
   post_freesurfer:
     fmri_res: 2
     freesurfer_labels: /opt/dcan-tools/pipeline/global/config/FreeSurferAllLut.txt
@@ -604,11 +602,6 @@ surface_analysis:
     run: true
     surface_parcellation_template: /cpac_templates/Schaefer2018_200Parcels_17Networks_order.dlabel.nii
 timeseries_extraction:
-  connectivity_matrix:
-    measure:
-    - Pearson
-    using:
-    - Nilearn
   realignment: ROI_to_func
   run: true
   tse_roi_paths:

--- a/configs/p023_base-abcd_perturb-rbc_step-structural-registration_conn-nilearn_nuisance-false.yml
+++ b/configs/p023_base-abcd_perturb-rbc_step-structural-registration_conn-nilearn_nuisance-false.yml
@@ -259,6 +259,7 @@ nuisance_corrections:
     - false
     space: native
 pipeline_setup:
+  freesurfer_dir: /ocean/projects/med220004p/trogers1/many_pipelines/freesurfer/outputs/ABCD_all_subjects
   Amazon-AWS:
     aws_output_bucket_credentials: null
     s3_encryption: false
@@ -309,7 +310,7 @@ pipeline_setup:
     random_seed: null
   working_directory:
     path: /outputs/working
-    remove_working_dir: true
+    remove_working_dir: false
 post_processing:
   spatial_smoothing:
     fwhm:
@@ -334,7 +335,7 @@ registration_workflows:
     T1w_brain_template_mask: $FSLDIR/data/standard/MNI152_T1_${resolution_for_anat}_brain_mask.nii.gz
     T1w_template: $FSLDIR/data/standard/MNI152_T1_${resolution_for_anat}.nii.gz
     overwrite_transform:
-      run: false
+      run: true
       using: FSL
     reg_with_skull: false
     registration:
@@ -398,12 +399,11 @@ registration_workflows:
       FSL-FNIRT:
         FNIRT_T1w_brain_template: null
         FNIRT_T1w_template: null
-        T1w_template_res-2: null
+        T1w_template_res-2: $FSLDIR/data/standard/MNI152_T1_2mm_brain_mask.nii.gz
         fnirt_config: T1_2_MNI152_2mm
         identity_matrix: $FSLDIR/etc/flirtsch/ident.mat
         interpolation: sinc
         ref_mask: null
-        ref_mask_res-2: null
         ref_resolution: 2mm
       using:
       - ANTS
@@ -494,8 +494,6 @@ registration_workflows:
           func_reg_input_volume: 0
         input:
         - Selected_Functional_Volume
-        reg_with_skull: true
-      input: brain
       interpolation: spline
       run: true
       using: FSL
@@ -586,7 +584,7 @@ surface_analysis:
   freesurfer:
     ingress_reconall: true
     reconall_args: null
-    run_reconall: true
+    run_reconall: false
   post_freesurfer:
     fmri_res: 2
     freesurfer_labels: /opt/dcan-tools/pipeline/global/config/FreeSurferAllLut.txt
@@ -604,11 +602,6 @@ surface_analysis:
     run: true
     surface_parcellation_template: /cpac_templates/Schaefer2018_200Parcels_17Networks_order.dlabel.nii
 timeseries_extraction:
-  connectivity_matrix:
-    measure:
-    - Pearson
-    using:
-    - Nilearn
   realignment: ROI_to_func
   run: true
   tse_roi_paths:

--- a/configs/p024_base-abcd_perturb-rbc_step-functional-masking_conn-afni_nuisance-true.yml
+++ b/configs/p024_base-abcd_perturb-rbc_step-functional-masking_conn-afni_nuisance-true.yml
@@ -259,6 +259,7 @@ nuisance_corrections:
     - true
     space: native
 pipeline_setup:
+  freesurfer_dir: /ocean/projects/med220004p/trogers1/many_pipelines/freesurfer/outputs/ABCD_all_subjects
   Amazon-AWS:
     aws_output_bucket_credentials: null
     s3_encryption: false
@@ -309,7 +310,7 @@ pipeline_setup:
     random_seed: null
   working_directory:
     path: /outputs/working
-    remove_working_dir: true
+    remove_working_dir: false
 post_processing:
   spatial_smoothing:
     fwhm:
@@ -403,12 +404,10 @@ registration_workflows:
       FSL-FNIRT:
         FNIRT_T1w_brain_template: null
         FNIRT_T1w_template: null
-        T1w_template_res-2: /opt/dcan-tools/pipeline/global/templates/MNI152_T1_2mm.nii.gz
         fnirt_config: T1_2_MNI152_2mm
         identity_matrix: $FSLDIR/etc/flirtsch/ident.mat
         interpolation: sinc
         ref_mask: $FSLDIR/data/standard/MNI152_T1_${resolution_for_anat}_brain_mask_dil.nii.gz
-        ref_mask_res-2: /opt/dcan-tools/pipeline/global/templates/MNI152_T1_2mm_brain_mask_dil.nii.gz
         ref_resolution: 2mm
       using:
       - ANTS
@@ -499,8 +498,6 @@ registration_workflows:
           func_reg_input_volume: 0
         input:
         - Selected_Functional_Volume
-        reg_with_skull: true
-      input: brain
       interpolation: spline
       run: true
       using: FSL
@@ -591,7 +588,7 @@ surface_analysis:
   freesurfer:
     ingress_reconall: true
     reconall_args: null
-    run_reconall: true
+    run_reconall: false
   post_freesurfer:
     fmri_res: 2
     freesurfer_labels: /opt/dcan-tools/pipeline/global/config/FreeSurferAllLut.txt
@@ -609,11 +606,6 @@ surface_analysis:
     run: true
     surface_parcellation_template: /cpac_templates/Schaefer2018_200Parcels_17Networks_order.dlabel.nii
 timeseries_extraction:
-  connectivity_matrix:
-    measure:
-    - Pearson
-    using:
-    - AFNI
   realignment: ROI_to_func
   run: true
   tse_roi_paths:

--- a/configs/p025_base-abcd_perturb-rbc_step-functional-masking_conn-afni_nuisance-false.yml
+++ b/configs/p025_base-abcd_perturb-rbc_step-functional-masking_conn-afni_nuisance-false.yml
@@ -259,6 +259,7 @@ nuisance_corrections:
     - false
     space: native
 pipeline_setup:
+  freesurfer_dir: /ocean/projects/med220004p/trogers1/many_pipelines/freesurfer/outputs/ABCD_all_subjects
   Amazon-AWS:
     aws_output_bucket_credentials: null
     s3_encryption: false
@@ -309,7 +310,7 @@ pipeline_setup:
     random_seed: null
   working_directory:
     path: /outputs/working
-    remove_working_dir: true
+    remove_working_dir: false
 post_processing:
   spatial_smoothing:
     fwhm:
@@ -403,12 +404,10 @@ registration_workflows:
       FSL-FNIRT:
         FNIRT_T1w_brain_template: null
         FNIRT_T1w_template: null
-        T1w_template_res-2: /opt/dcan-tools/pipeline/global/templates/MNI152_T1_2mm.nii.gz
         fnirt_config: T1_2_MNI152_2mm
         identity_matrix: $FSLDIR/etc/flirtsch/ident.mat
         interpolation: sinc
         ref_mask: $FSLDIR/data/standard/MNI152_T1_${resolution_for_anat}_brain_mask_dil.nii.gz
-        ref_mask_res-2: /opt/dcan-tools/pipeline/global/templates/MNI152_T1_2mm_brain_mask_dil.nii.gz
         ref_resolution: 2mm
       using:
       - ANTS
@@ -499,8 +498,6 @@ registration_workflows:
           func_reg_input_volume: 0
         input:
         - Selected_Functional_Volume
-        reg_with_skull: true
-      input: brain
       interpolation: spline
       run: true
       using: FSL
@@ -591,7 +588,7 @@ surface_analysis:
   freesurfer:
     ingress_reconall: true
     reconall_args: null
-    run_reconall: true
+    run_reconall: false
   post_freesurfer:
     fmri_res: 2
     freesurfer_labels: /opt/dcan-tools/pipeline/global/config/FreeSurferAllLut.txt
@@ -609,11 +606,6 @@ surface_analysis:
     run: true
     surface_parcellation_template: /cpac_templates/Schaefer2018_200Parcels_17Networks_order.dlabel.nii
 timeseries_extraction:
-  connectivity_matrix:
-    measure:
-    - Pearson
-    using:
-    - AFNI
   realignment: ROI_to_func
   run: true
   tse_roi_paths:

--- a/configs/p026_base-abcd_perturb-rbc_step-functional-masking_conn-nilearn_nuisance-true.yml
+++ b/configs/p026_base-abcd_perturb-rbc_step-functional-masking_conn-nilearn_nuisance-true.yml
@@ -259,6 +259,7 @@ nuisance_corrections:
     - true
     space: native
 pipeline_setup:
+  freesurfer_dir: /ocean/projects/med220004p/trogers1/many_pipelines/freesurfer/outputs/ABCD_all_subjects
   Amazon-AWS:
     aws_output_bucket_credentials: null
     s3_encryption: false
@@ -309,7 +310,7 @@ pipeline_setup:
     random_seed: null
   working_directory:
     path: /outputs/working
-    remove_working_dir: true
+    remove_working_dir: false
 post_processing:
   spatial_smoothing:
     fwhm:
@@ -403,12 +404,10 @@ registration_workflows:
       FSL-FNIRT:
         FNIRT_T1w_brain_template: null
         FNIRT_T1w_template: null
-        T1w_template_res-2: /opt/dcan-tools/pipeline/global/templates/MNI152_T1_2mm.nii.gz
         fnirt_config: T1_2_MNI152_2mm
         identity_matrix: $FSLDIR/etc/flirtsch/ident.mat
         interpolation: sinc
         ref_mask: $FSLDIR/data/standard/MNI152_T1_${resolution_for_anat}_brain_mask_dil.nii.gz
-        ref_mask_res-2: /opt/dcan-tools/pipeline/global/templates/MNI152_T1_2mm_brain_mask_dil.nii.gz
         ref_resolution: 2mm
       using:
       - ANTS
@@ -499,8 +498,6 @@ registration_workflows:
           func_reg_input_volume: 0
         input:
         - Selected_Functional_Volume
-        reg_with_skull: true
-      input: brain
       interpolation: spline
       run: true
       using: FSL
@@ -591,7 +588,7 @@ surface_analysis:
   freesurfer:
     ingress_reconall: true
     reconall_args: null
-    run_reconall: true
+    run_reconall: false
   post_freesurfer:
     fmri_res: 2
     freesurfer_labels: /opt/dcan-tools/pipeline/global/config/FreeSurferAllLut.txt
@@ -609,11 +606,6 @@ surface_analysis:
     run: true
     surface_parcellation_template: /cpac_templates/Schaefer2018_200Parcels_17Networks_order.dlabel.nii
 timeseries_extraction:
-  connectivity_matrix:
-    measure:
-    - Pearson
-    using:
-    - Nilearn
   realignment: ROI_to_func
   run: true
   tse_roi_paths:

--- a/configs/p027_base-abcd_perturb-rbc_step-functional-masking_conn-nilearn_nuisance-false.yml
+++ b/configs/p027_base-abcd_perturb-rbc_step-functional-masking_conn-nilearn_nuisance-false.yml
@@ -259,6 +259,7 @@ nuisance_corrections:
     - false
     space: native
 pipeline_setup:
+  freesurfer_dir: /ocean/projects/med220004p/trogers1/many_pipelines/freesurfer/outputs/ABCD_all_subjects
   Amazon-AWS:
     aws_output_bucket_credentials: null
     s3_encryption: false
@@ -309,7 +310,7 @@ pipeline_setup:
     random_seed: null
   working_directory:
     path: /outputs/working
-    remove_working_dir: true
+    remove_working_dir: false
 post_processing:
   spatial_smoothing:
     fwhm:
@@ -403,12 +404,10 @@ registration_workflows:
       FSL-FNIRT:
         FNIRT_T1w_brain_template: null
         FNIRT_T1w_template: null
-        T1w_template_res-2: /opt/dcan-tools/pipeline/global/templates/MNI152_T1_2mm.nii.gz
         fnirt_config: T1_2_MNI152_2mm
         identity_matrix: $FSLDIR/etc/flirtsch/ident.mat
         interpolation: sinc
         ref_mask: $FSLDIR/data/standard/MNI152_T1_${resolution_for_anat}_brain_mask_dil.nii.gz
-        ref_mask_res-2: /opt/dcan-tools/pipeline/global/templates/MNI152_T1_2mm_brain_mask_dil.nii.gz
         ref_resolution: 2mm
       using:
       - ANTS
@@ -499,8 +498,6 @@ registration_workflows:
           func_reg_input_volume: 0
         input:
         - Selected_Functional_Volume
-        reg_with_skull: true
-      input: brain
       interpolation: spline
       run: true
       using: FSL
@@ -591,7 +588,7 @@ surface_analysis:
   freesurfer:
     ingress_reconall: true
     reconall_args: null
-    run_reconall: true
+    run_reconall: false
   post_freesurfer:
     fmri_res: 2
     freesurfer_labels: /opt/dcan-tools/pipeline/global/config/FreeSurferAllLut.txt
@@ -609,11 +606,6 @@ surface_analysis:
     run: true
     surface_parcellation_template: /cpac_templates/Schaefer2018_200Parcels_17Networks_order.dlabel.nii
 timeseries_extraction:
-  connectivity_matrix:
-    measure:
-    - Pearson
-    using:
-    - Nilearn
   realignment: ROI_to_func
   run: true
   tse_roi_paths:

--- a/configs/p028_base-abcd_perturb-rbc_step-functional-registration_conn-afni_nuisance-true.yml
+++ b/configs/p028_base-abcd_perturb-rbc_step-functional-registration_conn-afni_nuisance-true.yml
@@ -149,7 +149,7 @@ functional_preproc:
     apply_func_mask_in_native_space: false
     run: true
     using:
-    - Anatomical_Resampled
+    - CCS_Anatomical_Refined
   generate_func_mean:
     run: true
   motion_estimates_and_correction:
@@ -259,6 +259,7 @@ nuisance_corrections:
     - true
     space: native
 pipeline_setup:
+  freesurfer_dir: /ocean/projects/med220004p/trogers1/many_pipelines/freesurfer/outputs/ABCD_all_subjects
   Amazon-AWS:
     aws_output_bucket_credentials: null
     s3_encryption: false
@@ -309,7 +310,7 @@ pipeline_setup:
     random_seed: null
   working_directory:
     path: /outputs/working
-    remove_working_dir: true
+    remove_working_dir: false
 post_processing:
   spatial_smoothing:
     fwhm:
@@ -403,12 +404,10 @@ registration_workflows:
       FSL-FNIRT:
         FNIRT_T1w_brain_template: null
         FNIRT_T1w_template: null
-        T1w_template_res-2: /opt/dcan-tools/pipeline/global/templates/MNI152_T1_2mm.nii.gz
         fnirt_config: T1_2_MNI152_2mm
         identity_matrix: $FSLDIR/etc/flirtsch/ident.mat
         interpolation: sinc
         ref_mask: $FSLDIR/data/standard/MNI152_T1_${resolution_for_anat}_brain_mask_dil.nii.gz
-        ref_mask_res-2: /opt/dcan-tools/pipeline/global/templates/MNI152_T1_2mm_brain_mask_dil.nii.gz
         ref_resolution: 2mm
       using:
       - ANTS
@@ -499,8 +498,6 @@ registration_workflows:
           func_reg_input_volume: 0
         input:
         - fmriprep_reference
-        reg_with_skull: false
-      input: brain
       interpolation: trilinear
       run: true
       using: FSL
@@ -591,7 +588,7 @@ surface_analysis:
   freesurfer:
     ingress_reconall: true
     reconall_args: null
-    run_reconall: true
+    run_reconall: false
   post_freesurfer:
     fmri_res: 2
     freesurfer_labels: /opt/dcan-tools/pipeline/global/config/FreeSurferAllLut.txt
@@ -609,11 +606,6 @@ surface_analysis:
     run: true
     surface_parcellation_template: /cpac_templates/Schaefer2018_200Parcels_17Networks_order.dlabel.nii
 timeseries_extraction:
-  connectivity_matrix:
-    measure:
-    - Pearson
-    using:
-    - AFNI
   realignment: ROI_to_func
   run: true
   tse_roi_paths:

--- a/configs/p029_base-abcd_perturb-rbc_step-functional-registration_conn-afni_nuisance-false.yml
+++ b/configs/p029_base-abcd_perturb-rbc_step-functional-registration_conn-afni_nuisance-false.yml
@@ -149,7 +149,7 @@ functional_preproc:
     apply_func_mask_in_native_space: false
     run: true
     using:
-    - Anatomical_Resampled
+    - CCS_Anatomical_Refined
   generate_func_mean:
     run: true
   motion_estimates_and_correction:
@@ -259,6 +259,7 @@ nuisance_corrections:
     - false
     space: native
 pipeline_setup:
+  freesurfer_dir: /ocean/projects/med220004p/trogers1/many_pipelines/freesurfer/outputs/ABCD_all_subjects
   Amazon-AWS:
     aws_output_bucket_credentials: null
     s3_encryption: false
@@ -309,7 +310,7 @@ pipeline_setup:
     random_seed: null
   working_directory:
     path: /outputs/working
-    remove_working_dir: true
+    remove_working_dir: false
 post_processing:
   spatial_smoothing:
     fwhm:
@@ -403,12 +404,10 @@ registration_workflows:
       FSL-FNIRT:
         FNIRT_T1w_brain_template: null
         FNIRT_T1w_template: null
-        T1w_template_res-2: /opt/dcan-tools/pipeline/global/templates/MNI152_T1_2mm.nii.gz
         fnirt_config: T1_2_MNI152_2mm
         identity_matrix: $FSLDIR/etc/flirtsch/ident.mat
         interpolation: sinc
         ref_mask: $FSLDIR/data/standard/MNI152_T1_${resolution_for_anat}_brain_mask_dil.nii.gz
-        ref_mask_res-2: /opt/dcan-tools/pipeline/global/templates/MNI152_T1_2mm_brain_mask_dil.nii.gz
         ref_resolution: 2mm
       using:
       - ANTS
@@ -499,8 +498,6 @@ registration_workflows:
           func_reg_input_volume: 0
         input:
         - fmriprep_reference
-        reg_with_skull: false
-      input: brain
       interpolation: trilinear
       run: true
       using: FSL
@@ -591,7 +588,7 @@ surface_analysis:
   freesurfer:
     ingress_reconall: true
     reconall_args: null
-    run_reconall: true
+    run_reconall: false
   post_freesurfer:
     fmri_res: 2
     freesurfer_labels: /opt/dcan-tools/pipeline/global/config/FreeSurferAllLut.txt
@@ -609,11 +606,6 @@ surface_analysis:
     run: true
     surface_parcellation_template: /cpac_templates/Schaefer2018_200Parcels_17Networks_order.dlabel.nii
 timeseries_extraction:
-  connectivity_matrix:
-    measure:
-    - Pearson
-    using:
-    - AFNI
   realignment: ROI_to_func
   run: true
   tse_roi_paths:

--- a/configs/p030_base-abcd_perturb-rbc_step-functional-registration_conn-nilearn_nuisance-true.yml
+++ b/configs/p030_base-abcd_perturb-rbc_step-functional-registration_conn-nilearn_nuisance-true.yml
@@ -149,7 +149,7 @@ functional_preproc:
     apply_func_mask_in_native_space: false
     run: true
     using:
-    - Anatomical_Resampled
+    - CCS_Anatomical_Refined
   generate_func_mean:
     run: true
   motion_estimates_and_correction:
@@ -259,6 +259,7 @@ nuisance_corrections:
     - true
     space: native
 pipeline_setup:
+  freesurfer_dir: /ocean/projects/med220004p/trogers1/many_pipelines/freesurfer/outputs/ABCD_all_subjects
   Amazon-AWS:
     aws_output_bucket_credentials: null
     s3_encryption: false
@@ -309,7 +310,7 @@ pipeline_setup:
     random_seed: null
   working_directory:
     path: /outputs/working
-    remove_working_dir: true
+    remove_working_dir: false
 post_processing:
   spatial_smoothing:
     fwhm:
@@ -403,12 +404,10 @@ registration_workflows:
       FSL-FNIRT:
         FNIRT_T1w_brain_template: null
         FNIRT_T1w_template: null
-        T1w_template_res-2: /opt/dcan-tools/pipeline/global/templates/MNI152_T1_2mm.nii.gz
         fnirt_config: T1_2_MNI152_2mm
         identity_matrix: $FSLDIR/etc/flirtsch/ident.mat
         interpolation: sinc
         ref_mask: $FSLDIR/data/standard/MNI152_T1_${resolution_for_anat}_brain_mask_dil.nii.gz
-        ref_mask_res-2: /opt/dcan-tools/pipeline/global/templates/MNI152_T1_2mm_brain_mask_dil.nii.gz
         ref_resolution: 2mm
       using:
       - ANTS
@@ -499,8 +498,6 @@ registration_workflows:
           func_reg_input_volume: 0
         input:
         - fmriprep_reference
-        reg_with_skull: false
-      input: brain
       interpolation: trilinear
       run: true
       using: FSL
@@ -591,7 +588,7 @@ surface_analysis:
   freesurfer:
     ingress_reconall: true
     reconall_args: null
-    run_reconall: true
+    run_reconall: false
   post_freesurfer:
     fmri_res: 2
     freesurfer_labels: /opt/dcan-tools/pipeline/global/config/FreeSurferAllLut.txt
@@ -609,11 +606,6 @@ surface_analysis:
     run: true
     surface_parcellation_template: /cpac_templates/Schaefer2018_200Parcels_17Networks_order.dlabel.nii
 timeseries_extraction:
-  connectivity_matrix:
-    measure:
-    - Pearson
-    using:
-    - Nilearn
   realignment: ROI_to_func
   run: true
   tse_roi_paths:

--- a/configs/p031_base-abcd_perturb-rbc_step-functional-registration_conn-nilearn_nuisance-false.yml
+++ b/configs/p031_base-abcd_perturb-rbc_step-functional-registration_conn-nilearn_nuisance-false.yml
@@ -149,7 +149,7 @@ functional_preproc:
     apply_func_mask_in_native_space: false
     run: true
     using:
-    - Anatomical_Resampled
+    - CCS_Anatomical_Refined
   generate_func_mean:
     run: true
   motion_estimates_and_correction:
@@ -259,6 +259,7 @@ nuisance_corrections:
     - false
     space: native
 pipeline_setup:
+  freesurfer_dir: /ocean/projects/med220004p/trogers1/many_pipelines/freesurfer/outputs/ABCD_all_subjects
   Amazon-AWS:
     aws_output_bucket_credentials: null
     s3_encryption: false
@@ -309,7 +310,7 @@ pipeline_setup:
     random_seed: null
   working_directory:
     path: /outputs/working
-    remove_working_dir: true
+    remove_working_dir: false
 post_processing:
   spatial_smoothing:
     fwhm:
@@ -403,12 +404,10 @@ registration_workflows:
       FSL-FNIRT:
         FNIRT_T1w_brain_template: null
         FNIRT_T1w_template: null
-        T1w_template_res-2: /opt/dcan-tools/pipeline/global/templates/MNI152_T1_2mm.nii.gz
         fnirt_config: T1_2_MNI152_2mm
         identity_matrix: $FSLDIR/etc/flirtsch/ident.mat
         interpolation: sinc
         ref_mask: $FSLDIR/data/standard/MNI152_T1_${resolution_for_anat}_brain_mask_dil.nii.gz
-        ref_mask_res-2: /opt/dcan-tools/pipeline/global/templates/MNI152_T1_2mm_brain_mask_dil.nii.gz
         ref_resolution: 2mm
       using:
       - ANTS
@@ -499,8 +498,6 @@ registration_workflows:
           func_reg_input_volume: 0
         input:
         - fmriprep_reference
-        reg_with_skull: false
-      input: brain
       interpolation: trilinear
       run: true
       using: FSL
@@ -591,7 +588,7 @@ surface_analysis:
   freesurfer:
     ingress_reconall: true
     reconall_args: null
-    run_reconall: true
+    run_reconall: false
   post_freesurfer:
     fmri_res: 2
     freesurfer_labels: /opt/dcan-tools/pipeline/global/config/FreeSurferAllLut.txt
@@ -609,11 +606,6 @@ surface_analysis:
     run: true
     surface_parcellation_template: /cpac_templates/Schaefer2018_200Parcels_17Networks_order.dlabel.nii
 timeseries_extraction:
-  connectivity_matrix:
-    measure:
-    - Pearson
-    using:
-    - Nilearn
   realignment: ROI_to_func
   run: true
   tse_roi_paths:

--- a/configs/p032_base-abcd_perturb-fmriprep_step-structural-masking_conn-afni_nuisance-true.yml
+++ b/configs/p032_base-abcd_perturb-fmriprep_step-structural-masking_conn-afni_nuisance-true.yml
@@ -259,6 +259,7 @@ nuisance_corrections:
     - true
     space: native
 pipeline_setup:
+  freesurfer_dir: /ocean/projects/med220004p/trogers1/many_pipelines/freesurfer/outputs/ABCD_all_subjects
   Amazon-AWS:
     aws_output_bucket_credentials: null
     s3_encryption: false
@@ -309,7 +310,7 @@ pipeline_setup:
     random_seed: null
   working_directory:
     path: /outputs/working
-    remove_working_dir: true
+    remove_working_dir: false
 post_processing:
   spatial_smoothing:
     fwhm:
@@ -403,12 +404,10 @@ registration_workflows:
       FSL-FNIRT:
         FNIRT_T1w_brain_template: null
         FNIRT_T1w_template: null
-        T1w_template_res-2: /opt/dcan-tools/pipeline/global/templates/MNI152_T1_2mm.nii.gz
         fnirt_config: T1_2_MNI152_2mm
         identity_matrix: $FSLDIR/etc/flirtsch/ident.mat
         interpolation: sinc
         ref_mask: $FSLDIR/data/standard/MNI152_T1_${resolution_for_anat}_brain_mask_dil.nii.gz
-        ref_mask_res-2: /opt/dcan-tools/pipeline/global/templates/MNI152_T1_2mm_brain_mask_dil.nii.gz
         ref_resolution: 2mm
       using:
       - ANTS
@@ -499,8 +498,6 @@ registration_workflows:
           func_reg_input_volume: 0
         input:
         - Selected_Functional_Volume
-        reg_with_skull: true
-      input: brain
       interpolation: spline
       run: true
       using: FSL
@@ -591,7 +588,7 @@ surface_analysis:
   freesurfer:
     ingress_reconall: true
     reconall_args: null
-    run_reconall: true
+    run_reconall: false
   post_freesurfer:
     fmri_res: 2
     freesurfer_labels: /opt/dcan-tools/pipeline/global/config/FreeSurferAllLut.txt
@@ -609,11 +606,6 @@ surface_analysis:
     run: true
     surface_parcellation_template: /cpac_templates/Schaefer2018_200Parcels_17Networks_order.dlabel.nii
 timeseries_extraction:
-  connectivity_matrix:
-    measure:
-    - Pearson
-    using:
-    - AFNI
   realignment: ROI_to_func
   run: true
   tse_roi_paths:

--- a/configs/p033_base-abcd_perturb-fmriprep_step-structural-masking_conn-afni_nuisance-false.yml
+++ b/configs/p033_base-abcd_perturb-fmriprep_step-structural-masking_conn-afni_nuisance-false.yml
@@ -259,6 +259,7 @@ nuisance_corrections:
     - false
     space: native
 pipeline_setup:
+  freesurfer_dir: /ocean/projects/med220004p/trogers1/many_pipelines/freesurfer/outputs/ABCD_all_subjects
   Amazon-AWS:
     aws_output_bucket_credentials: null
     s3_encryption: false
@@ -309,7 +310,7 @@ pipeline_setup:
     random_seed: null
   working_directory:
     path: /outputs/working
-    remove_working_dir: true
+    remove_working_dir: false
 post_processing:
   spatial_smoothing:
     fwhm:
@@ -403,12 +404,10 @@ registration_workflows:
       FSL-FNIRT:
         FNIRT_T1w_brain_template: null
         FNIRT_T1w_template: null
-        T1w_template_res-2: /opt/dcan-tools/pipeline/global/templates/MNI152_T1_2mm.nii.gz
         fnirt_config: T1_2_MNI152_2mm
         identity_matrix: $FSLDIR/etc/flirtsch/ident.mat
         interpolation: sinc
         ref_mask: $FSLDIR/data/standard/MNI152_T1_${resolution_for_anat}_brain_mask_dil.nii.gz
-        ref_mask_res-2: /opt/dcan-tools/pipeline/global/templates/MNI152_T1_2mm_brain_mask_dil.nii.gz
         ref_resolution: 2mm
       using:
       - ANTS
@@ -499,8 +498,6 @@ registration_workflows:
           func_reg_input_volume: 0
         input:
         - Selected_Functional_Volume
-        reg_with_skull: true
-      input: brain
       interpolation: spline
       run: true
       using: FSL
@@ -591,7 +588,7 @@ surface_analysis:
   freesurfer:
     ingress_reconall: true
     reconall_args: null
-    run_reconall: true
+    run_reconall: false
   post_freesurfer:
     fmri_res: 2
     freesurfer_labels: /opt/dcan-tools/pipeline/global/config/FreeSurferAllLut.txt
@@ -609,11 +606,6 @@ surface_analysis:
     run: true
     surface_parcellation_template: /cpac_templates/Schaefer2018_200Parcels_17Networks_order.dlabel.nii
 timeseries_extraction:
-  connectivity_matrix:
-    measure:
-    - Pearson
-    using:
-    - AFNI
   realignment: ROI_to_func
   run: true
   tse_roi_paths:

--- a/configs/p034_base-abcd_perturb-fmriprep_step-structural-masking_conn-nilearn_nuisance-true.yml
+++ b/configs/p034_base-abcd_perturb-fmriprep_step-structural-masking_conn-nilearn_nuisance-true.yml
@@ -259,6 +259,7 @@ nuisance_corrections:
     - true
     space: native
 pipeline_setup:
+  freesurfer_dir: /ocean/projects/med220004p/trogers1/many_pipelines/freesurfer/outputs/ABCD_all_subjects
   Amazon-AWS:
     aws_output_bucket_credentials: null
     s3_encryption: false
@@ -309,7 +310,7 @@ pipeline_setup:
     random_seed: null
   working_directory:
     path: /outputs/working
-    remove_working_dir: true
+    remove_working_dir: false
 post_processing:
   spatial_smoothing:
     fwhm:
@@ -403,12 +404,10 @@ registration_workflows:
       FSL-FNIRT:
         FNIRT_T1w_brain_template: null
         FNIRT_T1w_template: null
-        T1w_template_res-2: /opt/dcan-tools/pipeline/global/templates/MNI152_T1_2mm.nii.gz
         fnirt_config: T1_2_MNI152_2mm
         identity_matrix: $FSLDIR/etc/flirtsch/ident.mat
         interpolation: sinc
         ref_mask: $FSLDIR/data/standard/MNI152_T1_${resolution_for_anat}_brain_mask_dil.nii.gz
-        ref_mask_res-2: /opt/dcan-tools/pipeline/global/templates/MNI152_T1_2mm_brain_mask_dil.nii.gz
         ref_resolution: 2mm
       using:
       - ANTS
@@ -499,8 +498,6 @@ registration_workflows:
           func_reg_input_volume: 0
         input:
         - Selected_Functional_Volume
-        reg_with_skull: true
-      input: brain
       interpolation: spline
       run: true
       using: FSL
@@ -591,7 +588,7 @@ surface_analysis:
   freesurfer:
     ingress_reconall: true
     reconall_args: null
-    run_reconall: true
+    run_reconall: false
   post_freesurfer:
     fmri_res: 2
     freesurfer_labels: /opt/dcan-tools/pipeline/global/config/FreeSurferAllLut.txt
@@ -609,11 +606,6 @@ surface_analysis:
     run: true
     surface_parcellation_template: /cpac_templates/Schaefer2018_200Parcels_17Networks_order.dlabel.nii
 timeseries_extraction:
-  connectivity_matrix:
-    measure:
-    - Pearson
-    using:
-    - Nilearn
   realignment: ROI_to_func
   run: true
   tse_roi_paths:

--- a/configs/p035_base-abcd_perturb-fmriprep_step-structural-masking_conn-nilearn_nuisance-false.yml
+++ b/configs/p035_base-abcd_perturb-fmriprep_step-structural-masking_conn-nilearn_nuisance-false.yml
@@ -259,6 +259,7 @@ nuisance_corrections:
     - false
     space: native
 pipeline_setup:
+  freesurfer_dir: /ocean/projects/med220004p/trogers1/many_pipelines/freesurfer/outputs/ABCD_all_subjects
   Amazon-AWS:
     aws_output_bucket_credentials: null
     s3_encryption: false
@@ -309,7 +310,7 @@ pipeline_setup:
     random_seed: null
   working_directory:
     path: /outputs/working
-    remove_working_dir: true
+    remove_working_dir: false
 post_processing:
   spatial_smoothing:
     fwhm:
@@ -403,12 +404,10 @@ registration_workflows:
       FSL-FNIRT:
         FNIRT_T1w_brain_template: null
         FNIRT_T1w_template: null
-        T1w_template_res-2: /opt/dcan-tools/pipeline/global/templates/MNI152_T1_2mm.nii.gz
         fnirt_config: T1_2_MNI152_2mm
         identity_matrix: $FSLDIR/etc/flirtsch/ident.mat
         interpolation: sinc
         ref_mask: $FSLDIR/data/standard/MNI152_T1_${resolution_for_anat}_brain_mask_dil.nii.gz
-        ref_mask_res-2: /opt/dcan-tools/pipeline/global/templates/MNI152_T1_2mm_brain_mask_dil.nii.gz
         ref_resolution: 2mm
       using:
       - ANTS
@@ -499,8 +498,6 @@ registration_workflows:
           func_reg_input_volume: 0
         input:
         - Selected_Functional_Volume
-        reg_with_skull: true
-      input: brain
       interpolation: spline
       run: true
       using: FSL
@@ -591,7 +588,7 @@ surface_analysis:
   freesurfer:
     ingress_reconall: true
     reconall_args: null
-    run_reconall: true
+    run_reconall: false
   post_freesurfer:
     fmri_res: 2
     freesurfer_labels: /opt/dcan-tools/pipeline/global/config/FreeSurferAllLut.txt
@@ -609,11 +606,6 @@ surface_analysis:
     run: true
     surface_parcellation_template: /cpac_templates/Schaefer2018_200Parcels_17Networks_order.dlabel.nii
 timeseries_extraction:
-  connectivity_matrix:
-    measure:
-    - Pearson
-    using:
-    - Nilearn
   realignment: ROI_to_func
   run: true
   tse_roi_paths:

--- a/configs/p036_base-abcd_perturb-fmriprep_step-structural-registration_conn-afni_nuisance-true.yml
+++ b/configs/p036_base-abcd_perturb-fmriprep_step-structural-registration_conn-afni_nuisance-true.yml
@@ -26,7 +26,7 @@ anatomical_preproc:
     acpc_target: whole-head
     align_brain_mask: false
     brain_size: 150
-    run: true
+    run: false
     run_before_preproc: false
   brain_extraction:
     AFNI-3dSkullStrip:
@@ -75,10 +75,10 @@ anatomical_preproc:
       template_path: /ants_template/oasis/T_template0.nii.gz
     run: true
     using:
-    - FreeSurfer-ABCD
+    - 3dSkullStrip
   n4_bias_field_correction:
     run:
-    - true
+    - false
     shrink_factor: 4
   non_local_means_filtering:
     noise_model: Rician
@@ -259,6 +259,7 @@ nuisance_corrections:
     - true
     space: native
 pipeline_setup:
+  freesurfer_dir: /ocean/projects/med220004p/trogers1/many_pipelines/freesurfer/outputs/ABCD_all_subjects
   Amazon-AWS:
     aws_output_bucket_credentials: null
     s3_encryption: false
@@ -309,7 +310,7 @@ pipeline_setup:
     random_seed: null
   working_directory:
     path: /outputs/working
-    remove_working_dir: true
+    remove_working_dir: false
 post_processing:
   spatial_smoothing:
     fwhm:
@@ -334,7 +335,7 @@ registration_workflows:
     T1w_brain_template_mask: /code/CPAC/resources/templates/tpl-MNI152NLin2009cAsym_res-01_desc-brain_mask.nii.gz
     T1w_template: /code/CPAC/resources/templates/mni_icbm152_t1_tal_nlin_asym_09c.nii
     overwrite_transform:
-      run: false
+      run: Off
       using: FSL
     reg_with_skull: false
     registration:
@@ -398,16 +399,16 @@ registration_workflows:
       FSL-FNIRT:
         FNIRT_T1w_brain_template: null
         FNIRT_T1w_template: null
-        T1w_template_res-2: null
+        T1w_template_res-2: $FSLDIR/data/standard/MNI152_T1_2mm_brain.nii.gz
         fnirt_config: T1_2_MNI152_2mm
         identity_matrix: $FSLDIR/etc/flirtsch/ident.mat
         interpolation: sinc
-        ref_mask: null
-        ref_mask_res-2: null
+        ref_mask: $FSLDIR/data/standard/MNI152_T1_2mm_brain_mask.nii.gz
+        ref_mask_res-2: $FSLDIR/data/standard/MNI152_T1_2mm_brain_mask.nii.gz
         ref_resolution: 2mm
       using:
-      - ANTS
-    resolution_for_anat: 1mm
+      - FSL
+    resolution_for_anat: 2mm
     run: true
   functional_registration:
     EPI_registration:
@@ -586,7 +587,7 @@ surface_analysis:
   freesurfer:
     ingress_reconall: true
     reconall_args: null
-    run_reconall: true
+    run_reconall: false
   post_freesurfer:
     fmri_res: 2
     freesurfer_labels: /opt/dcan-tools/pipeline/global/config/FreeSurferAllLut.txt
@@ -604,11 +605,6 @@ surface_analysis:
     run: true
     surface_parcellation_template: /cpac_templates/Schaefer2018_200Parcels_17Networks_order.dlabel.nii
 timeseries_extraction:
-  connectivity_matrix:
-    measure:
-    - Pearson
-    using:
-    - AFNI
   realignment: ROI_to_func
   run: true
   tse_roi_paths:

--- a/configs/p037_base-abcd_perturb-fmriprep_step-structural-registration_conn-afni_nuisance-false.yml
+++ b/configs/p037_base-abcd_perturb-fmriprep_step-structural-registration_conn-afni_nuisance-false.yml
@@ -259,6 +259,7 @@ nuisance_corrections:
     - false
     space: native
 pipeline_setup:
+  freesurfer_dir: /ocean/projects/med220004p/trogers1/many_pipelines/freesurfer/outputs/ABCD_all_subjects
   Amazon-AWS:
     aws_output_bucket_credentials: null
     s3_encryption: false
@@ -309,7 +310,7 @@ pipeline_setup:
     random_seed: null
   working_directory:
     path: /outputs/working
-    remove_working_dir: true
+    remove_working_dir: false
 post_processing:
   spatial_smoothing:
     fwhm:
@@ -334,7 +335,7 @@ registration_workflows:
     T1w_brain_template_mask: /code/CPAC/resources/templates/tpl-MNI152NLin2009cAsym_res-01_desc-brain_mask.nii.gz
     T1w_template: /code/CPAC/resources/templates/mni_icbm152_t1_tal_nlin_asym_09c.nii
     overwrite_transform:
-      run: false
+      run: Off
       using: FSL
     reg_with_skull: false
     registration:
@@ -398,16 +399,16 @@ registration_workflows:
       FSL-FNIRT:
         FNIRT_T1w_brain_template: null
         FNIRT_T1w_template: null
-        T1w_template_res-2: null
+        T1w_template_res-2: $FSLDIR/data/standard/MNI152_T1_2mm_brain.nii.gz
         fnirt_config: T1_2_MNI152_2mm
         identity_matrix: $FSLDIR/etc/flirtsch/ident.mat
         interpolation: sinc
-        ref_mask: null
-        ref_mask_res-2: null
+        ref_mask: $FSLDIR/data/standard/MNI152_T1_2mm_brain_mask.nii.gz
+        ref_mask_res-2: $FSLDIR/data/standard/MNI152_T1_2mm_brain_mask.nii.gz
         ref_resolution: 2mm
       using:
-      - ANTS
-    resolution_for_anat: 1mm
+      - FSL
+    resolution_for_anat: 2mm
     run: true
   functional_registration:
     EPI_registration:
@@ -586,7 +587,7 @@ surface_analysis:
   freesurfer:
     ingress_reconall: true
     reconall_args: null
-    run_reconall: true
+    run_reconall: false
   post_freesurfer:
     fmri_res: 2
     freesurfer_labels: /opt/dcan-tools/pipeline/global/config/FreeSurferAllLut.txt
@@ -604,11 +605,6 @@ surface_analysis:
     run: true
     surface_parcellation_template: /cpac_templates/Schaefer2018_200Parcels_17Networks_order.dlabel.nii
 timeseries_extraction:
-  connectivity_matrix:
-    measure:
-    - Pearson
-    using:
-    - AFNI
   realignment: ROI_to_func
   run: true
   tse_roi_paths:

--- a/configs/p038_base-abcd_perturb-fmriprep_step-structural-registration_conn-nilearn_nuisance-true.yml
+++ b/configs/p038_base-abcd_perturb-fmriprep_step-structural-registration_conn-nilearn_nuisance-true.yml
@@ -259,6 +259,7 @@ nuisance_corrections:
     - true
     space: native
 pipeline_setup:
+  freesurfer_dir: /ocean/projects/med220004p/trogers1/many_pipelines/freesurfer/outputs/ABCD_all_subjects
   Amazon-AWS:
     aws_output_bucket_credentials: null
     s3_encryption: false
@@ -309,7 +310,7 @@ pipeline_setup:
     random_seed: null
   working_directory:
     path: /outputs/working
-    remove_working_dir: true
+    remove_working_dir: false
 post_processing:
   spatial_smoothing:
     fwhm:
@@ -334,7 +335,7 @@ registration_workflows:
     T1w_brain_template_mask: /code/CPAC/resources/templates/tpl-MNI152NLin2009cAsym_res-01_desc-brain_mask.nii.gz
     T1w_template: /code/CPAC/resources/templates/mni_icbm152_t1_tal_nlin_asym_09c.nii
     overwrite_transform:
-      run: false
+      run: Off
       using: FSL
     reg_with_skull: false
     registration:
@@ -398,16 +399,16 @@ registration_workflows:
       FSL-FNIRT:
         FNIRT_T1w_brain_template: null
         FNIRT_T1w_template: null
-        T1w_template_res-2: null
+        T1w_template_res-2: $FSLDIR/data/standard/MNI152_T1_2mm_brain.nii.gz
         fnirt_config: T1_2_MNI152_2mm
-        identity_matrix: $FSLDIR/etc/flirtsch/ident.mat
+        identity_matrix: $FSLDIR/etc/flirtsch/ident.mat 
         interpolation: sinc
-        ref_mask: null
-        ref_mask_res-2: null
+        ref_mask: $FSLDIR/data/standard/MNI152_T1_2mm_brain_mask.nii.gz
+        ref_mask_res-2: $FSLDIR/data/standard/MNI152_T1_2mm_brain_mask.nii.gz
         ref_resolution: 2mm
       using:
-      - ANTS
-    resolution_for_anat: 1mm
+      - FSL
+    resolution_for_anat: 2mm
     run: true
   functional_registration:
     EPI_registration:
@@ -586,7 +587,7 @@ surface_analysis:
   freesurfer:
     ingress_reconall: true
     reconall_args: null
-    run_reconall: true
+    run_reconall: false
   post_freesurfer:
     fmri_res: 2
     freesurfer_labels: /opt/dcan-tools/pipeline/global/config/FreeSurferAllLut.txt
@@ -604,11 +605,6 @@ surface_analysis:
     run: true
     surface_parcellation_template: /cpac_templates/Schaefer2018_200Parcels_17Networks_order.dlabel.nii
 timeseries_extraction:
-  connectivity_matrix:
-    measure:
-    - Pearson
-    using:
-    - Nilearn
   realignment: ROI_to_func
   run: true
   tse_roi_paths:

--- a/configs/p039_base-abcd_perturb-fmriprep_step-structural-registration_conn-nilearn_nuisance-false.yml
+++ b/configs/p039_base-abcd_perturb-fmriprep_step-structural-registration_conn-nilearn_nuisance-false.yml
@@ -259,6 +259,7 @@ nuisance_corrections:
     - false
     space: native
 pipeline_setup:
+  freesurfer_dir: /ocean/projects/med220004p/trogers1/many_pipelines/freesurfer/outputs/ABCD_all_subjects
   Amazon-AWS:
     aws_output_bucket_credentials: null
     s3_encryption: false
@@ -309,7 +310,7 @@ pipeline_setup:
     random_seed: null
   working_directory:
     path: /outputs/working
-    remove_working_dir: true
+    remove_working_dir: false
 post_processing:
   spatial_smoothing:
     fwhm:
@@ -334,7 +335,7 @@ registration_workflows:
     T1w_brain_template_mask: /code/CPAC/resources/templates/tpl-MNI152NLin2009cAsym_res-01_desc-brain_mask.nii.gz
     T1w_template: /code/CPAC/resources/templates/mni_icbm152_t1_tal_nlin_asym_09c.nii
     overwrite_transform:
-      run: false
+      run: Off
       using: FSL
     reg_with_skull: false
     registration:
@@ -398,16 +399,16 @@ registration_workflows:
       FSL-FNIRT:
         FNIRT_T1w_brain_template: null
         FNIRT_T1w_template: null
-        T1w_template_res-2: null
+        T1w_template_res-2: $FSLDIR/data/standard/MNI152_T1_2mm_brain.nii.gz
         fnirt_config: T1_2_MNI152_2mm
         identity_matrix: $FSLDIR/etc/flirtsch/ident.mat
         interpolation: sinc
-        ref_mask: null
-        ref_mask_res-2: null
+        ref_mask: $FSLDIR/data/standard/MNI152_T1_2mm_brain_mask.nii.gz
+        ref_mask_res-2: $FSLDIR/data/standard/MNI152_T1_2mm_brain_mask.nii.gz
         ref_resolution: 2mm
       using:
-      - ANTS
-    resolution_for_anat: 1mm
+      - FSL
+    resolution_for_anat: 2mm
     run: true
   functional_registration:
     EPI_registration:
@@ -586,7 +587,7 @@ surface_analysis:
   freesurfer:
     ingress_reconall: true
     reconall_args: null
-    run_reconall: true
+    run_reconall: false
   post_freesurfer:
     fmri_res: 2
     freesurfer_labels: /opt/dcan-tools/pipeline/global/config/FreeSurferAllLut.txt
@@ -604,11 +605,6 @@ surface_analysis:
     run: true
     surface_parcellation_template: /cpac_templates/Schaefer2018_200Parcels_17Networks_order.dlabel.nii
 timeseries_extraction:
-  connectivity_matrix:
-    measure:
-    - Pearson
-    using:
-    - Nilearn
   realignment: ROI_to_func
   run: true
   tse_roi_paths:

--- a/configs/p040_base-abcd_perturb-fmriprep_step-functional-masking_conn-afni_nuisance-true.yml
+++ b/configs/p040_base-abcd_perturb-fmriprep_step-functional-masking_conn-afni_nuisance-true.yml
@@ -259,6 +259,7 @@ nuisance_corrections:
     - true
     space: native
 pipeline_setup:
+  freesurfer_dir: /ocean/projects/med220004p/trogers1/many_pipelines/freesurfer/outputs/ABCD_all_subjects
   Amazon-AWS:
     aws_output_bucket_credentials: null
     s3_encryption: false
@@ -309,7 +310,7 @@ pipeline_setup:
     random_seed: null
   working_directory:
     path: /outputs/working
-    remove_working_dir: true
+    remove_working_dir: false
 post_processing:
   spatial_smoothing:
     fwhm:
@@ -403,12 +404,10 @@ registration_workflows:
       FSL-FNIRT:
         FNIRT_T1w_brain_template: null
         FNIRT_T1w_template: null
-        T1w_template_res-2: /opt/dcan-tools/pipeline/global/templates/MNI152_T1_2mm.nii.gz
         fnirt_config: T1_2_MNI152_2mm
         identity_matrix: $FSLDIR/etc/flirtsch/ident.mat
         interpolation: sinc
         ref_mask: $FSLDIR/data/standard/MNI152_T1_${resolution_for_anat}_brain_mask_dil.nii.gz
-        ref_mask_res-2: /opt/dcan-tools/pipeline/global/templates/MNI152_T1_2mm_brain_mask_dil.nii.gz
         ref_resolution: 2mm
       using:
       - ANTS
@@ -499,8 +498,6 @@ registration_workflows:
           func_reg_input_volume: 0
         input:
         - Selected_Functional_Volume
-        reg_with_skull: true
-      input: brain
       interpolation: spline
       run: true
       using: FSL
@@ -591,7 +588,7 @@ surface_analysis:
   freesurfer:
     ingress_reconall: true
     reconall_args: null
-    run_reconall: true
+    run_reconall: false
   post_freesurfer:
     fmri_res: 2
     freesurfer_labels: /opt/dcan-tools/pipeline/global/config/FreeSurferAllLut.txt
@@ -609,11 +606,6 @@ surface_analysis:
     run: true
     surface_parcellation_template: /cpac_templates/Schaefer2018_200Parcels_17Networks_order.dlabel.nii
 timeseries_extraction:
-  connectivity_matrix:
-    measure:
-    - Pearson
-    using:
-    - AFNI
   realignment: ROI_to_func
   run: true
   tse_roi_paths:

--- a/configs/p041_base-abcd_perturb-fmriprep_step-functional-masking_conn-afni_nuisance-false.yml
+++ b/configs/p041_base-abcd_perturb-fmriprep_step-functional-masking_conn-afni_nuisance-false.yml
@@ -259,6 +259,7 @@ nuisance_corrections:
     - false
     space: native
 pipeline_setup:
+  freesurfer_dir: /ocean/projects/med220004p/trogers1/many_pipelines/freesurfer/outputs/ABCD_all_subjects
   Amazon-AWS:
     aws_output_bucket_credentials: null
     s3_encryption: false
@@ -309,7 +310,7 @@ pipeline_setup:
     random_seed: null
   working_directory:
     path: /outputs/working
-    remove_working_dir: true
+    remove_working_dir: false
 post_processing:
   spatial_smoothing:
     fwhm:
@@ -403,12 +404,10 @@ registration_workflows:
       FSL-FNIRT:
         FNIRT_T1w_brain_template: null
         FNIRT_T1w_template: null
-        T1w_template_res-2: /opt/dcan-tools/pipeline/global/templates/MNI152_T1_2mm.nii.gz
         fnirt_config: T1_2_MNI152_2mm
         identity_matrix: $FSLDIR/etc/flirtsch/ident.mat
         interpolation: sinc
         ref_mask: $FSLDIR/data/standard/MNI152_T1_${resolution_for_anat}_brain_mask_dil.nii.gz
-        ref_mask_res-2: /opt/dcan-tools/pipeline/global/templates/MNI152_T1_2mm_brain_mask_dil.nii.gz
         ref_resolution: 2mm
       using:
       - ANTS
@@ -499,8 +498,6 @@ registration_workflows:
           func_reg_input_volume: 0
         input:
         - Selected_Functional_Volume
-        reg_with_skull: true
-      input: brain
       interpolation: spline
       run: true
       using: FSL
@@ -591,7 +588,7 @@ surface_analysis:
   freesurfer:
     ingress_reconall: true
     reconall_args: null
-    run_reconall: true
+    run_reconall: false
   post_freesurfer:
     fmri_res: 2
     freesurfer_labels: /opt/dcan-tools/pipeline/global/config/FreeSurferAllLut.txt
@@ -609,11 +606,6 @@ surface_analysis:
     run: true
     surface_parcellation_template: /cpac_templates/Schaefer2018_200Parcels_17Networks_order.dlabel.nii
 timeseries_extraction:
-  connectivity_matrix:
-    measure:
-    - Pearson
-    using:
-    - AFNI
   realignment: ROI_to_func
   run: true
   tse_roi_paths:

--- a/configs/p042_base-abcd_perturb-fmriprep_step-functional-masking_conn-nilearn_nuisance-true.yml
+++ b/configs/p042_base-abcd_perturb-fmriprep_step-functional-masking_conn-nilearn_nuisance-true.yml
@@ -259,6 +259,7 @@ nuisance_corrections:
     - true
     space: native
 pipeline_setup:
+  freesurfer_dir: /ocean/projects/med220004p/trogers1/many_pipelines/freesurfer/outputs/ABCD_all_subjects
   Amazon-AWS:
     aws_output_bucket_credentials: null
     s3_encryption: false
@@ -309,7 +310,7 @@ pipeline_setup:
     random_seed: null
   working_directory:
     path: /outputs/working
-    remove_working_dir: true
+    remove_working_dir: false
 post_processing:
   spatial_smoothing:
     fwhm:
@@ -403,12 +404,10 @@ registration_workflows:
       FSL-FNIRT:
         FNIRT_T1w_brain_template: null
         FNIRT_T1w_template: null
-        T1w_template_res-2: /opt/dcan-tools/pipeline/global/templates/MNI152_T1_2mm.nii.gz
         fnirt_config: T1_2_MNI152_2mm
         identity_matrix: $FSLDIR/etc/flirtsch/ident.mat
         interpolation: sinc
         ref_mask: $FSLDIR/data/standard/MNI152_T1_${resolution_for_anat}_brain_mask_dil.nii.gz
-        ref_mask_res-2: /opt/dcan-tools/pipeline/global/templates/MNI152_T1_2mm_brain_mask_dil.nii.gz
         ref_resolution: 2mm
       using:
       - ANTS
@@ -499,8 +498,6 @@ registration_workflows:
           func_reg_input_volume: 0
         input:
         - Selected_Functional_Volume
-        reg_with_skull: true
-      input: brain
       interpolation: spline
       run: true
       using: FSL
@@ -591,7 +588,7 @@ surface_analysis:
   freesurfer:
     ingress_reconall: true
     reconall_args: null
-    run_reconall: true
+    run_reconall: false
   post_freesurfer:
     fmri_res: 2
     freesurfer_labels: /opt/dcan-tools/pipeline/global/config/FreeSurferAllLut.txt
@@ -609,11 +606,6 @@ surface_analysis:
     run: true
     surface_parcellation_template: /cpac_templates/Schaefer2018_200Parcels_17Networks_order.dlabel.nii
 timeseries_extraction:
-  connectivity_matrix:
-    measure:
-    - Pearson
-    using:
-    - Nilearn
   realignment: ROI_to_func
   run: true
   tse_roi_paths:

--- a/configs/p043_base-abcd_perturb-fmriprep_step-functional-masking_conn-nilearn_nuisance-false.yml
+++ b/configs/p043_base-abcd_perturb-fmriprep_step-functional-masking_conn-nilearn_nuisance-false.yml
@@ -259,6 +259,7 @@ nuisance_corrections:
     - false
     space: native
 pipeline_setup:
+  freesurfer_dir: /ocean/projects/med220004p/trogers1/many_pipelines/freesurfer/outputs/ABCD_all_subjects
   Amazon-AWS:
     aws_output_bucket_credentials: null
     s3_encryption: false
@@ -309,7 +310,7 @@ pipeline_setup:
     random_seed: null
   working_directory:
     path: /outputs/working
-    remove_working_dir: true
+    remove_working_dir: false
 post_processing:
   spatial_smoothing:
     fwhm:
@@ -403,12 +404,10 @@ registration_workflows:
       FSL-FNIRT:
         FNIRT_T1w_brain_template: null
         FNIRT_T1w_template: null
-        T1w_template_res-2: /opt/dcan-tools/pipeline/global/templates/MNI152_T1_2mm.nii.gz
         fnirt_config: T1_2_MNI152_2mm
         identity_matrix: $FSLDIR/etc/flirtsch/ident.mat
         interpolation: sinc
         ref_mask: $FSLDIR/data/standard/MNI152_T1_${resolution_for_anat}_brain_mask_dil.nii.gz
-        ref_mask_res-2: /opt/dcan-tools/pipeline/global/templates/MNI152_T1_2mm_brain_mask_dil.nii.gz
         ref_resolution: 2mm
       using:
       - ANTS
@@ -499,8 +498,6 @@ registration_workflows:
           func_reg_input_volume: 0
         input:
         - Selected_Functional_Volume
-        reg_with_skull: true
-      input: brain
       interpolation: spline
       run: true
       using: FSL
@@ -591,7 +588,7 @@ surface_analysis:
   freesurfer:
     ingress_reconall: true
     reconall_args: null
-    run_reconall: true
+    run_reconall: false
   post_freesurfer:
     fmri_res: 2
     freesurfer_labels: /opt/dcan-tools/pipeline/global/config/FreeSurferAllLut.txt
@@ -609,11 +606,6 @@ surface_analysis:
     run: true
     surface_parcellation_template: /cpac_templates/Schaefer2018_200Parcels_17Networks_order.dlabel.nii
 timeseries_extraction:
-  connectivity_matrix:
-    measure:
-    - Pearson
-    using:
-    - Nilearn
   realignment: ROI_to_func
   run: true
   tse_roi_paths:

--- a/configs/p044_base-abcd_perturb-fmriprep_step-functional-registration_conn-afni_nuisance-true.yml
+++ b/configs/p044_base-abcd_perturb-fmriprep_step-functional-registration_conn-afni_nuisance-true.yml
@@ -149,7 +149,7 @@ functional_preproc:
     apply_func_mask_in_native_space: false
     run: true
     using:
-    - Anatomical_Resampled
+    - CCS_Anatomical_Refined
   generate_func_mean:
     run: true
   motion_estimates_and_correction:
@@ -259,6 +259,7 @@ nuisance_corrections:
     - true
     space: native
 pipeline_setup:
+  freesurfer_dir: /ocean/projects/med220004p/trogers1/many_pipelines/freesurfer/outputs/ABCD_all_subjects
   Amazon-AWS:
     aws_output_bucket_credentials: null
     s3_encryption: false
@@ -309,7 +310,7 @@ pipeline_setup:
     random_seed: null
   working_directory:
     path: /outputs/working
-    remove_working_dir: true
+    remove_working_dir: false
 post_processing:
   spatial_smoothing:
     fwhm:
@@ -403,12 +404,10 @@ registration_workflows:
       FSL-FNIRT:
         FNIRT_T1w_brain_template: null
         FNIRT_T1w_template: null
-        T1w_template_res-2: /opt/dcan-tools/pipeline/global/templates/MNI152_T1_2mm.nii.gz
         fnirt_config: T1_2_MNI152_2mm
         identity_matrix: $FSLDIR/etc/flirtsch/ident.mat
         interpolation: sinc
         ref_mask: $FSLDIR/data/standard/MNI152_T1_${resolution_for_anat}_brain_mask_dil.nii.gz
-        ref_mask_res-2: /opt/dcan-tools/pipeline/global/templates/MNI152_T1_2mm_brain_mask_dil.nii.gz
         ref_resolution: 2mm
       using:
       - ANTS
@@ -499,8 +498,6 @@ registration_workflows:
           func_reg_input_volume: 0
         input:
         - fmriprep_reference
-        reg_with_skull: false
-      input: brain
       interpolation: trilinear
       run: true
       using: FSL
@@ -591,7 +588,7 @@ surface_analysis:
   freesurfer:
     ingress_reconall: true
     reconall_args: null
-    run_reconall: true
+    run_reconall: false
   post_freesurfer:
     fmri_res: 2
     freesurfer_labels: /opt/dcan-tools/pipeline/global/config/FreeSurferAllLut.txt
@@ -609,11 +606,6 @@ surface_analysis:
     run: true
     surface_parcellation_template: /cpac_templates/Schaefer2018_200Parcels_17Networks_order.dlabel.nii
 timeseries_extraction:
-  connectivity_matrix:
-    measure:
-    - Pearson
-    using:
-    - AFNI
   realignment: ROI_to_func
   run: true
   tse_roi_paths:

--- a/configs/p045_base-abcd_perturb-fmriprep_step-functional-registration_conn-afni_nuisance-false.yml
+++ b/configs/p045_base-abcd_perturb-fmriprep_step-functional-registration_conn-afni_nuisance-false.yml
@@ -149,7 +149,7 @@ functional_preproc:
     apply_func_mask_in_native_space: false
     run: true
     using:
-    - Anatomical_Resampled
+    - CCS_Anatomical_Refined
   generate_func_mean:
     run: true
   motion_estimates_and_correction:
@@ -259,6 +259,7 @@ nuisance_corrections:
     - false
     space: native
 pipeline_setup:
+  freesurfer_dir: /ocean/projects/med220004p/trogers1/many_pipelines/freesurfer/outputs/ABCD_all_subjects
   Amazon-AWS:
     aws_output_bucket_credentials: null
     s3_encryption: false
@@ -309,7 +310,7 @@ pipeline_setup:
     random_seed: null
   working_directory:
     path: /outputs/working
-    remove_working_dir: true
+    remove_working_dir: false
 post_processing:
   spatial_smoothing:
     fwhm:
@@ -403,12 +404,10 @@ registration_workflows:
       FSL-FNIRT:
         FNIRT_T1w_brain_template: null
         FNIRT_T1w_template: null
-        T1w_template_res-2: /opt/dcan-tools/pipeline/global/templates/MNI152_T1_2mm.nii.gz
         fnirt_config: T1_2_MNI152_2mm
         identity_matrix: $FSLDIR/etc/flirtsch/ident.mat
         interpolation: sinc
         ref_mask: $FSLDIR/data/standard/MNI152_T1_${resolution_for_anat}_brain_mask_dil.nii.gz
-        ref_mask_res-2: /opt/dcan-tools/pipeline/global/templates/MNI152_T1_2mm_brain_mask_dil.nii.gz
         ref_resolution: 2mm
       using:
       - ANTS
@@ -499,8 +498,6 @@ registration_workflows:
           func_reg_input_volume: 0
         input:
         - fmriprep_reference
-        reg_with_skull: false
-      input: brain
       interpolation: trilinear
       run: true
       using: FSL
@@ -591,7 +588,7 @@ surface_analysis:
   freesurfer:
     ingress_reconall: true
     reconall_args: null
-    run_reconall: true
+    run_reconall: false
   post_freesurfer:
     fmri_res: 2
     freesurfer_labels: /opt/dcan-tools/pipeline/global/config/FreeSurferAllLut.txt
@@ -609,11 +606,6 @@ surface_analysis:
     run: true
     surface_parcellation_template: /cpac_templates/Schaefer2018_200Parcels_17Networks_order.dlabel.nii
 timeseries_extraction:
-  connectivity_matrix:
-    measure:
-    - Pearson
-    using:
-    - AFNI
   realignment: ROI_to_func
   run: true
   tse_roi_paths:

--- a/configs/p046_base-abcd_perturb-fmriprep_step-functional-registration_conn-nilearn_nuisance-true.yml
+++ b/configs/p046_base-abcd_perturb-fmriprep_step-functional-registration_conn-nilearn_nuisance-true.yml
@@ -149,7 +149,7 @@ functional_preproc:
     apply_func_mask_in_native_space: false
     run: true
     using:
-    - Anatomical_Resampled
+    - CCS_Anatomical_Refined
   generate_func_mean:
     run: true
   motion_estimates_and_correction:
@@ -259,6 +259,7 @@ nuisance_corrections:
     - true
     space: native
 pipeline_setup:
+  freesurfer_dir: /ocean/projects/med220004p/trogers1/many_pipelines/freesurfer/outputs/ABCD_all_subjects
   Amazon-AWS:
     aws_output_bucket_credentials: null
     s3_encryption: false
@@ -309,7 +310,7 @@ pipeline_setup:
     random_seed: null
   working_directory:
     path: /outputs/working
-    remove_working_dir: true
+    remove_working_dir: false
 post_processing:
   spatial_smoothing:
     fwhm:
@@ -403,12 +404,10 @@ registration_workflows:
       FSL-FNIRT:
         FNIRT_T1w_brain_template: null
         FNIRT_T1w_template: null
-        T1w_template_res-2: /opt/dcan-tools/pipeline/global/templates/MNI152_T1_2mm.nii.gz
         fnirt_config: T1_2_MNI152_2mm
         identity_matrix: $FSLDIR/etc/flirtsch/ident.mat
         interpolation: sinc
         ref_mask: $FSLDIR/data/standard/MNI152_T1_${resolution_for_anat}_brain_mask_dil.nii.gz
-        ref_mask_res-2: /opt/dcan-tools/pipeline/global/templates/MNI152_T1_2mm_brain_mask_dil.nii.gz
         ref_resolution: 2mm
       using:
       - ANTS
@@ -499,8 +498,6 @@ registration_workflows:
           func_reg_input_volume: 0
         input:
         - fmriprep_reference
-        reg_with_skull: false
-      input: brain
       interpolation: trilinear
       run: true
       using: FSL
@@ -591,7 +588,7 @@ surface_analysis:
   freesurfer:
     ingress_reconall: true
     reconall_args: null
-    run_reconall: true
+    run_reconall: false
   post_freesurfer:
     fmri_res: 2
     freesurfer_labels: /opt/dcan-tools/pipeline/global/config/FreeSurferAllLut.txt
@@ -609,11 +606,6 @@ surface_analysis:
     run: true
     surface_parcellation_template: /cpac_templates/Schaefer2018_200Parcels_17Networks_order.dlabel.nii
 timeseries_extraction:
-  connectivity_matrix:
-    measure:
-    - Pearson
-    using:
-    - Nilearn
   realignment: ROI_to_func
   run: true
   tse_roi_paths:

--- a/configs/p047_base-abcd_perturb-fmriprep_step-functional-registration_conn-nilearn_nuisance-false.yml
+++ b/configs/p047_base-abcd_perturb-fmriprep_step-functional-registration_conn-nilearn_nuisance-false.yml
@@ -149,7 +149,7 @@ functional_preproc:
     apply_func_mask_in_native_space: false
     run: true
     using:
-    - Anatomical_Resampled
+    - CCS_Anatomical_Refined
   generate_func_mean:
     run: true
   motion_estimates_and_correction:
@@ -259,6 +259,7 @@ nuisance_corrections:
     - false
     space: native
 pipeline_setup:
+  freesurfer_dir: /ocean/projects/med220004p/trogers1/many_pipelines/freesurfer/outputs/ABCD_all_subjects
   Amazon-AWS:
     aws_output_bucket_credentials: null
     s3_encryption: false
@@ -309,7 +310,7 @@ pipeline_setup:
     random_seed: null
   working_directory:
     path: /outputs/working
-    remove_working_dir: true
+    remove_working_dir: false
 post_processing:
   spatial_smoothing:
     fwhm:
@@ -403,12 +404,10 @@ registration_workflows:
       FSL-FNIRT:
         FNIRT_T1w_brain_template: null
         FNIRT_T1w_template: null
-        T1w_template_res-2: /opt/dcan-tools/pipeline/global/templates/MNI152_T1_2mm.nii.gz
         fnirt_config: T1_2_MNI152_2mm
         identity_matrix: $FSLDIR/etc/flirtsch/ident.mat
         interpolation: sinc
         ref_mask: $FSLDIR/data/standard/MNI152_T1_${resolution_for_anat}_brain_mask_dil.nii.gz
-        ref_mask_res-2: /opt/dcan-tools/pipeline/global/templates/MNI152_T1_2mm_brain_mask_dil.nii.gz
         ref_resolution: 2mm
       using:
       - ANTS
@@ -499,8 +498,6 @@ registration_workflows:
           func_reg_input_volume: 0
         input:
         - fmriprep_reference
-        reg_with_skull: false
-      input: brain
       interpolation: trilinear
       run: true
       using: FSL
@@ -591,7 +588,7 @@ surface_analysis:
   freesurfer:
     ingress_reconall: true
     reconall_args: null
-    run_reconall: true
+    run_reconall: false
   post_freesurfer:
     fmri_res: 2
     freesurfer_labels: /opt/dcan-tools/pipeline/global/config/FreeSurferAllLut.txt
@@ -609,11 +606,6 @@ surface_analysis:
     run: true
     surface_parcellation_template: /cpac_templates/Schaefer2018_200Parcels_17Networks_order.dlabel.nii
 timeseries_extraction:
-  connectivity_matrix:
-    measure:
-    - Pearson
-    using:
-    - Nilearn
   realignment: ROI_to_func
   run: true
   tse_roi_paths:

--- a/configs/p048_base-ccs_perturb-abcd_step-structural-masking_conn-afni_nuisance-true.yml
+++ b/configs/p048_base-ccs_perturb-abcd_step-structural-masking_conn-afni_nuisance-true.yml
@@ -290,6 +290,7 @@ nuisance_corrections:
     - true
     space: native
 pipeline_setup:
+  freesurfer_dir: /ocean/projects/med220004p/trogers1/many_pipelines/freesurfer/outputs/ABCD_all_subjects
   Amazon-AWS:
     aws_output_bucket_credentials: null
     s3_encryption: false
@@ -340,7 +341,7 @@ pipeline_setup:
     random_seed: null
   working_directory:
     path: /outputs/working
-    remove_working_dir: true
+    remove_working_dir: false
 post_processing:
   spatial_smoothing:
     fwhm:
@@ -365,7 +366,7 @@ registration_workflows:
     T1w_brain_template_mask: $FSLDIR/data/standard/MNI152_T1_${resolution_for_anat}_brain_mask.nii.gz
     T1w_template: $FSLDIR/data/standard/MNI152_T1_${resolution_for_anat}.nii.gz
     overwrite_transform:
-      run: false
+      run: Off
       using: FSL
     reg_with_skull: false
     registration:
@@ -434,7 +435,6 @@ registration_workflows:
         identity_matrix: $FSLDIR/etc/flirtsch/ident.mat
         interpolation: trilinear
         ref_mask: $FSLDIR/data/standard/MNI152_T1_${resolution_for_anat}_brain_mask_dil.nii.gz
-        ref_mask_res-2: $FSLDIR/data/standard/MNI152_T1_2mm_brain_mask_dil.nii.gz
         ref_resolution: 2mm
       using:
       - FSL
@@ -525,8 +525,6 @@ registration_workflows:
           func_reg_input_volume: 7
         input:
         - Selected_Functional_Volume
-        reg_with_skull: false
-      input: brain
       interpolation: trilinear
       run: true
       using: FSL
@@ -623,13 +621,13 @@ segmentation:
     - FSL-FAST
 surface_analysis:
   abcd_prefreesurfer_prep:
-    run: false
+    run: true
   amplitude_low_frequency_fluctuation:
     run: false
   freesurfer:
     ingress_reconall: true
     reconall_args: -clean-bm -gcut
-    run_reconall: true
+    run_reconall: false
   post_freesurfer:
     fmri_res: 2
     freesurfer_labels: /opt/dcan-tools/pipeline/global/config/FreeSurferAllLut.txt
@@ -647,11 +645,6 @@ surface_analysis:
     run: false
     surface_parcellation_template: /cpac_templates/Schaefer2018_200Parcels_17Networks_order.dlabel.nii
 timeseries_extraction:
-  connectivity_matrix:
-    measure:
-    - Pearson
-    using:
-    - AFNI
   realignment: ROI_to_func
   run: true
   tse_roi_paths:

--- a/configs/p049_base-ccs_perturb-abcd_step-structural-masking_conn-afni_nuisance-false.yml
+++ b/configs/p049_base-ccs_perturb-abcd_step-structural-masking_conn-afni_nuisance-false.yml
@@ -290,6 +290,7 @@ nuisance_corrections:
     - false
     space: native
 pipeline_setup:
+  freesurfer_dir: /ocean/projects/med220004p/trogers1/many_pipelines/freesurfer/outputs/ABCD_all_subjects
   Amazon-AWS:
     aws_output_bucket_credentials: null
     s3_encryption: false
@@ -340,7 +341,7 @@ pipeline_setup:
     random_seed: null
   working_directory:
     path: /outputs/working
-    remove_working_dir: true
+    remove_working_dir: false
 post_processing:
   spatial_smoothing:
     fwhm:
@@ -365,7 +366,7 @@ registration_workflows:
     T1w_brain_template_mask: $FSLDIR/data/standard/MNI152_T1_${resolution_for_anat}_brain_mask.nii.gz
     T1w_template: $FSLDIR/data/standard/MNI152_T1_${resolution_for_anat}.nii.gz
     overwrite_transform:
-      run: false
+      run: Off
       using: FSL
     reg_with_skull: false
     registration:
@@ -434,7 +435,6 @@ registration_workflows:
         identity_matrix: $FSLDIR/etc/flirtsch/ident.mat
         interpolation: trilinear
         ref_mask: $FSLDIR/data/standard/MNI152_T1_${resolution_for_anat}_brain_mask_dil.nii.gz
-        ref_mask_res-2: $FSLDIR/data/standard/MNI152_T1_2mm_brain_mask_dil.nii.gz
         ref_resolution: 2mm
       using:
       - FSL
@@ -525,8 +525,6 @@ registration_workflows:
           func_reg_input_volume: 7
         input:
         - Selected_Functional_Volume
-        reg_with_skull: false
-      input: brain
       interpolation: trilinear
       run: true
       using: FSL
@@ -623,13 +621,13 @@ segmentation:
     - FSL-FAST
 surface_analysis:
   abcd_prefreesurfer_prep:
-    run: false
+    run: true
   amplitude_low_frequency_fluctuation:
     run: false
   freesurfer:
     ingress_reconall: true
     reconall_args: -clean-bm -gcut
-    run_reconall: true
+    run_reconall: false
   post_freesurfer:
     fmri_res: 2
     freesurfer_labels: /opt/dcan-tools/pipeline/global/config/FreeSurferAllLut.txt
@@ -647,11 +645,6 @@ surface_analysis:
     run: false
     surface_parcellation_template: /cpac_templates/Schaefer2018_200Parcels_17Networks_order.dlabel.nii
 timeseries_extraction:
-  connectivity_matrix:
-    measure:
-    - Pearson
-    using:
-    - AFNI
   realignment: ROI_to_func
   run: true
   tse_roi_paths:

--- a/configs/p050_base-ccs_perturb-abcd_step-structural-masking_conn-nilearn_nuisance-true.yml
+++ b/configs/p050_base-ccs_perturb-abcd_step-structural-masking_conn-nilearn_nuisance-true.yml
@@ -290,6 +290,7 @@ nuisance_corrections:
     - true
     space: native
 pipeline_setup:
+  freesurfer_dir: /ocean/projects/med220004p/trogers1/many_pipelines/freesurfer/outputs/ABCD_all_subjects
   Amazon-AWS:
     aws_output_bucket_credentials: null
     s3_encryption: false
@@ -340,7 +341,7 @@ pipeline_setup:
     random_seed: null
   working_directory:
     path: /outputs/working
-    remove_working_dir: true
+    remove_working_dir: false
 post_processing:
   spatial_smoothing:
     fwhm:
@@ -365,7 +366,7 @@ registration_workflows:
     T1w_brain_template_mask: $FSLDIR/data/standard/MNI152_T1_${resolution_for_anat}_brain_mask.nii.gz
     T1w_template: $FSLDIR/data/standard/MNI152_T1_${resolution_for_anat}.nii.gz
     overwrite_transform:
-      run: false
+      run: Off
       using: FSL
     reg_with_skull: false
     registration:
@@ -434,7 +435,6 @@ registration_workflows:
         identity_matrix: $FSLDIR/etc/flirtsch/ident.mat
         interpolation: trilinear
         ref_mask: $FSLDIR/data/standard/MNI152_T1_${resolution_for_anat}_brain_mask_dil.nii.gz
-        ref_mask_res-2: $FSLDIR/data/standard/MNI152_T1_2mm_brain_mask_dil.nii.gz
         ref_resolution: 2mm
       using:
       - FSL
@@ -525,8 +525,6 @@ registration_workflows:
           func_reg_input_volume: 7
         input:
         - Selected_Functional_Volume
-        reg_with_skull: false
-      input: brain
       interpolation: trilinear
       run: true
       using: FSL
@@ -623,13 +621,13 @@ segmentation:
     - FSL-FAST
 surface_analysis:
   abcd_prefreesurfer_prep:
-    run: false
+    run: true
   amplitude_low_frequency_fluctuation:
     run: false
   freesurfer:
     ingress_reconall: true
     reconall_args: -clean-bm -gcut
-    run_reconall: true
+    run_reconall: false
   post_freesurfer:
     fmri_res: 2
     freesurfer_labels: /opt/dcan-tools/pipeline/global/config/FreeSurferAllLut.txt
@@ -647,11 +645,6 @@ surface_analysis:
     run: false
     surface_parcellation_template: /cpac_templates/Schaefer2018_200Parcels_17Networks_order.dlabel.nii
 timeseries_extraction:
-  connectivity_matrix:
-    measure:
-    - Pearson
-    using:
-    - Nilearn
   realignment: ROI_to_func
   run: true
   tse_roi_paths:

--- a/configs/p051_base-ccs_perturb-abcd_step-structural-masking_conn-nilearn_nuisance-false.yml
+++ b/configs/p051_base-ccs_perturb-abcd_step-structural-masking_conn-nilearn_nuisance-false.yml
@@ -290,6 +290,7 @@ nuisance_corrections:
     - false
     space: native
 pipeline_setup:
+  freesurfer_dir: /ocean/projects/med220004p/trogers1/many_pipelines/freesurfer/outputs/ABCD_all_subjects
   Amazon-AWS:
     aws_output_bucket_credentials: null
     s3_encryption: false
@@ -340,7 +341,7 @@ pipeline_setup:
     random_seed: null
   working_directory:
     path: /outputs/working
-    remove_working_dir: true
+    remove_working_dir: false
 post_processing:
   spatial_smoothing:
     fwhm:
@@ -365,7 +366,7 @@ registration_workflows:
     T1w_brain_template_mask: $FSLDIR/data/standard/MNI152_T1_${resolution_for_anat}_brain_mask.nii.gz
     T1w_template: $FSLDIR/data/standard/MNI152_T1_${resolution_for_anat}.nii.gz
     overwrite_transform:
-      run: false
+      run: Off
       using: FSL
     reg_with_skull: false
     registration:
@@ -434,7 +435,6 @@ registration_workflows:
         identity_matrix: $FSLDIR/etc/flirtsch/ident.mat
         interpolation: trilinear
         ref_mask: $FSLDIR/data/standard/MNI152_T1_${resolution_for_anat}_brain_mask_dil.nii.gz
-        ref_mask_res-2: $FSLDIR/data/standard/MNI152_T1_2mm_brain_mask_dil.nii.gz
         ref_resolution: 2mm
       using:
       - FSL
@@ -525,8 +525,6 @@ registration_workflows:
           func_reg_input_volume: 7
         input:
         - Selected_Functional_Volume
-        reg_with_skull: false
-      input: brain
       interpolation: trilinear
       run: true
       using: FSL
@@ -623,13 +621,13 @@ segmentation:
     - FSL-FAST
 surface_analysis:
   abcd_prefreesurfer_prep:
-    run: false
+    run: true
   amplitude_low_frequency_fluctuation:
     run: false
   freesurfer:
     ingress_reconall: true
     reconall_args: -clean-bm -gcut
-    run_reconall: true
+    run_reconall: false
   post_freesurfer:
     fmri_res: 2
     freesurfer_labels: /opt/dcan-tools/pipeline/global/config/FreeSurferAllLut.txt
@@ -647,11 +645,6 @@ surface_analysis:
     run: false
     surface_parcellation_template: /cpac_templates/Schaefer2018_200Parcels_17Networks_order.dlabel.nii
 timeseries_extraction:
-  connectivity_matrix:
-    measure:
-    - Pearson
-    using:
-    - Nilearn
   realignment: ROI_to_func
   run: true
   tse_roi_paths:

--- a/configs/p052_base-ccs_perturb-abcd_step-structural-registration_conn-afni_nuisance-true.yml
+++ b/configs/p052_base-ccs_perturb-abcd_step-structural-registration_conn-afni_nuisance-true.yml
@@ -292,6 +292,7 @@ nuisance_corrections:
     - true
     space: native
 pipeline_setup:
+  freesurfer_dir: /ocean/projects/med220004p/trogers1/many_pipelines/freesurfer/outputs/ABCD_all_subjects
   Amazon-AWS:
     aws_output_bucket_credentials: null
     s3_encryption: false
@@ -342,7 +343,7 @@ pipeline_setup:
     random_seed: null
   working_directory:
     path: /outputs/working
-    remove_working_dir: true
+    remove_working_dir: false
 post_processing:
   spatial_smoothing:
     fwhm:
@@ -436,12 +437,10 @@ registration_workflows:
       FSL-FNIRT:
         FNIRT_T1w_brain_template: null
         FNIRT_T1w_template: null
-        T1w_template_res-2: /opt/dcan-tools/pipeline/global/templates/MNI152_T1_2mm.nii.gz
         fnirt_config: T1_2_MNI152_2mm
         identity_matrix: $FSLDIR/etc/flirtsch/ident.mat
         interpolation: sinc
         ref_mask: $FSLDIR/data/standard/MNI152_T1_${resolution_for_anat}_brain_mask_dil.nii.gz
-        ref_mask_res-2: /opt/dcan-tools/pipeline/global/templates/MNI152_T1_2mm_brain_mask_dil.nii.gz
         ref_resolution: 2mm
       using:
       - ANTS
@@ -532,8 +531,6 @@ registration_workflows:
           func_reg_input_volume: 7
         input:
         - Selected_Functional_Volume
-        reg_with_skull: false
-      input: brain
       interpolation: trilinear
       run: true
       using: FSL
@@ -636,7 +633,7 @@ surface_analysis:
   freesurfer:
     ingress_reconall: true
     reconall_args: -clean-bm -gcut
-    run_reconall: true
+    run_reconall: false
   post_freesurfer:
     fmri_res: 2
     freesurfer_labels: /opt/dcan-tools/pipeline/global/config/FreeSurferAllLut.txt
@@ -654,11 +651,6 @@ surface_analysis:
     run: false
     surface_parcellation_template: /cpac_templates/Schaefer2018_200Parcels_17Networks_order.dlabel.nii
 timeseries_extraction:
-  connectivity_matrix:
-    measure:
-    - Pearson
-    using:
-    - AFNI
   realignment: ROI_to_func
   run: true
   tse_roi_paths:

--- a/configs/p053_base-ccs_perturb-abcd_step-structural-registration_conn-afni_nuisance-false.yml
+++ b/configs/p053_base-ccs_perturb-abcd_step-structural-registration_conn-afni_nuisance-false.yml
@@ -292,6 +292,7 @@ nuisance_corrections:
     - false
     space: native
 pipeline_setup:
+  freesurfer_dir: /ocean/projects/med220004p/trogers1/many_pipelines/freesurfer/outputs/ABCD_all_subjects
   Amazon-AWS:
     aws_output_bucket_credentials: null
     s3_encryption: false
@@ -342,7 +343,7 @@ pipeline_setup:
     random_seed: null
   working_directory:
     path: /outputs/working
-    remove_working_dir: true
+    remove_working_dir: false
 post_processing:
   spatial_smoothing:
     fwhm:
@@ -436,12 +437,10 @@ registration_workflows:
       FSL-FNIRT:
         FNIRT_T1w_brain_template: null
         FNIRT_T1w_template: null
-        T1w_template_res-2: /opt/dcan-tools/pipeline/global/templates/MNI152_T1_2mm.nii.gz
         fnirt_config: T1_2_MNI152_2mm
         identity_matrix: $FSLDIR/etc/flirtsch/ident.mat
         interpolation: sinc
         ref_mask: $FSLDIR/data/standard/MNI152_T1_${resolution_for_anat}_brain_mask_dil.nii.gz
-        ref_mask_res-2: /opt/dcan-tools/pipeline/global/templates/MNI152_T1_2mm_brain_mask_dil.nii.gz
         ref_resolution: 2mm
       using:
       - ANTS
@@ -532,8 +531,6 @@ registration_workflows:
           func_reg_input_volume: 7
         input:
         - Selected_Functional_Volume
-        reg_with_skull: false
-      input: brain
       interpolation: trilinear
       run: true
       using: FSL
@@ -636,7 +633,7 @@ surface_analysis:
   freesurfer:
     ingress_reconall: true
     reconall_args: -clean-bm -gcut
-    run_reconall: true
+    run_reconall: false
   post_freesurfer:
     fmri_res: 2
     freesurfer_labels: /opt/dcan-tools/pipeline/global/config/FreeSurferAllLut.txt
@@ -654,11 +651,6 @@ surface_analysis:
     run: false
     surface_parcellation_template: /cpac_templates/Schaefer2018_200Parcels_17Networks_order.dlabel.nii
 timeseries_extraction:
-  connectivity_matrix:
-    measure:
-    - Pearson
-    using:
-    - AFNI
   realignment: ROI_to_func
   run: true
   tse_roi_paths:

--- a/configs/p054_base-ccs_perturb-abcd_step-structural-registration_conn-nilearn_nuisance-true.yml
+++ b/configs/p054_base-ccs_perturb-abcd_step-structural-registration_conn-nilearn_nuisance-true.yml
@@ -292,6 +292,7 @@ nuisance_corrections:
     - true
     space: native
 pipeline_setup:
+  freesurfer_dir: /ocean/projects/med220004p/trogers1/many_pipelines/freesurfer/outputs/ABCD_all_subjects
   Amazon-AWS:
     aws_output_bucket_credentials: null
     s3_encryption: false
@@ -342,7 +343,7 @@ pipeline_setup:
     random_seed: null
   working_directory:
     path: /outputs/working
-    remove_working_dir: true
+    remove_working_dir: false
 post_processing:
   spatial_smoothing:
     fwhm:
@@ -436,12 +437,10 @@ registration_workflows:
       FSL-FNIRT:
         FNIRT_T1w_brain_template: null
         FNIRT_T1w_template: null
-        T1w_template_res-2: /opt/dcan-tools/pipeline/global/templates/MNI152_T1_2mm.nii.gz
         fnirt_config: T1_2_MNI152_2mm
         identity_matrix: $FSLDIR/etc/flirtsch/ident.mat
         interpolation: sinc
         ref_mask: $FSLDIR/data/standard/MNI152_T1_${resolution_for_anat}_brain_mask_dil.nii.gz
-        ref_mask_res-2: /opt/dcan-tools/pipeline/global/templates/MNI152_T1_2mm_brain_mask_dil.nii.gz
         ref_resolution: 2mm
       using:
       - ANTS
@@ -532,8 +531,6 @@ registration_workflows:
           func_reg_input_volume: 7
         input:
         - Selected_Functional_Volume
-        reg_with_skull: false
-      input: brain
       interpolation: trilinear
       run: true
       using: FSL
@@ -636,7 +633,7 @@ surface_analysis:
   freesurfer:
     ingress_reconall: true
     reconall_args: -clean-bm -gcut
-    run_reconall: true
+    run_reconall: false
   post_freesurfer:
     fmri_res: 2
     freesurfer_labels: /opt/dcan-tools/pipeline/global/config/FreeSurferAllLut.txt
@@ -654,11 +651,6 @@ surface_analysis:
     run: false
     surface_parcellation_template: /cpac_templates/Schaefer2018_200Parcels_17Networks_order.dlabel.nii
 timeseries_extraction:
-  connectivity_matrix:
-    measure:
-    - Pearson
-    using:
-    - Nilearn
   realignment: ROI_to_func
   run: true
   tse_roi_paths:

--- a/configs/p055_base-ccs_perturb-abcd_step-structural-registration_conn-nilearn_nuisance-false.yml
+++ b/configs/p055_base-ccs_perturb-abcd_step-structural-registration_conn-nilearn_nuisance-false.yml
@@ -292,6 +292,7 @@ nuisance_corrections:
     - false
     space: native
 pipeline_setup:
+  freesurfer_dir: /ocean/projects/med220004p/trogers1/many_pipelines/freesurfer/outputs/ABCD_all_subjects
   Amazon-AWS:
     aws_output_bucket_credentials: null
     s3_encryption: false
@@ -342,7 +343,7 @@ pipeline_setup:
     random_seed: null
   working_directory:
     path: /outputs/working
-    remove_working_dir: true
+    remove_working_dir: false
 post_processing:
   spatial_smoothing:
     fwhm:
@@ -436,12 +437,10 @@ registration_workflows:
       FSL-FNIRT:
         FNIRT_T1w_brain_template: null
         FNIRT_T1w_template: null
-        T1w_template_res-2: /opt/dcan-tools/pipeline/global/templates/MNI152_T1_2mm.nii.gz
         fnirt_config: T1_2_MNI152_2mm
         identity_matrix: $FSLDIR/etc/flirtsch/ident.mat
         interpolation: sinc
         ref_mask: $FSLDIR/data/standard/MNI152_T1_${resolution_for_anat}_brain_mask_dil.nii.gz
-        ref_mask_res-2: /opt/dcan-tools/pipeline/global/templates/MNI152_T1_2mm_brain_mask_dil.nii.gz
         ref_resolution: 2mm
       using:
       - ANTS
@@ -532,8 +531,6 @@ registration_workflows:
           func_reg_input_volume: 7
         input:
         - Selected_Functional_Volume
-        reg_with_skull: false
-      input: brain
       interpolation: trilinear
       run: true
       using: FSL
@@ -636,7 +633,7 @@ surface_analysis:
   freesurfer:
     ingress_reconall: true
     reconall_args: -clean-bm -gcut
-    run_reconall: true
+    run_reconall: false
   post_freesurfer:
     fmri_res: 2
     freesurfer_labels: /opt/dcan-tools/pipeline/global/config/FreeSurferAllLut.txt
@@ -654,11 +651,6 @@ surface_analysis:
     run: false
     surface_parcellation_template: /cpac_templates/Schaefer2018_200Parcels_17Networks_order.dlabel.nii
 timeseries_extraction:
-  connectivity_matrix:
-    measure:
-    - Pearson
-    using:
-    - Nilearn
   realignment: ROI_to_func
   run: true
   tse_roi_paths:

--- a/configs/p056_base-ccs_perturb-abcd_step-functional-masking_conn-afni_nuisance-true.yml
+++ b/configs/p056_base-ccs_perturb-abcd_step-functional-masking_conn-afni_nuisance-true.yml
@@ -148,7 +148,7 @@ functional_preproc:
       bold_ref: null
       brain_mask: $FSLDIR/data/standard/MNI152_T1_${resolution_for_anat}_brain_mask.nii.gz
       brain_probseg: $FSLDIR/data/standard/MNI152_T1_${resolution_for_anat}_brain_mask.nii.gz
-    apply_func_mask_in_native_space: false
+    apply_func_mask_in_native_space: true
     run: true
     using:
     - Anatomical_Resampled
@@ -266,7 +266,7 @@ nuisance_corrections:
         - global_signal
         Name: default
       run: false
-    lateral_ventricles_mask: $FSLDIR/data/atlases/HarvardOxford/HarvardOxford-lateral-ventricles-thr25-2mm.nii.gz
+    lateral_ventricles_mask: None
     regressor_masks:
       erode_anatomical_brain_mask:
         brain_erosion_mm: null
@@ -292,6 +292,7 @@ nuisance_corrections:
     - true
     space: native
 pipeline_setup:
+  freesurfer_dir: /ocean/projects/med220004p/trogers1/many_pipelines/freesurfer/outputs/ABCD_all_subjects
   Amazon-AWS:
     aws_output_bucket_credentials: null
     s3_encryption: false
@@ -342,7 +343,7 @@ pipeline_setup:
     random_seed: null
   working_directory:
     path: /outputs/working
-    remove_working_dir: true
+    remove_working_dir: false
 post_processing:
   spatial_smoothing:
     fwhm:
@@ -436,7 +437,6 @@ registration_workflows:
         identity_matrix: $FSLDIR/etc/flirtsch/ident.mat
         interpolation: trilinear
         ref_mask: $FSLDIR/data/standard/MNI152_T1_${resolution_for_anat}_brain_mask_dil.nii.gz
-        ref_mask_res-2: $FSLDIR/data/standard/MNI152_T1_2mm_brain_mask_dil.nii.gz
         ref_resolution: 2mm
       using:
       - FSL
@@ -527,8 +527,6 @@ registration_workflows:
           func_reg_input_volume: 7
         input:
         - Selected_Functional_Volume
-        reg_with_skull: false
-      input: brain
       interpolation: trilinear
       run: true
       using: FSL
@@ -592,7 +590,7 @@ segmentation:
         GM_path: $priors_path/avg152T1_gray_bin.nii.gz
         WM_path: $priors_path/avg152T1_white_bin.nii.gz
         priors_path: $FSLDIR/data/standard/tissuepriors/2mm
-        run: true
+        run: false
     FreeSurfer:
       CSF_label:
       - 4
@@ -631,7 +629,7 @@ surface_analysis:
   freesurfer:
     ingress_reconall: true
     reconall_args: -clean-bm -gcut
-    run_reconall: true
+    run_reconall: false
   post_freesurfer:
     fmri_res: 2
     freesurfer_labels: /opt/dcan-tools/pipeline/global/config/FreeSurferAllLut.txt
@@ -649,11 +647,6 @@ surface_analysis:
     run: false
     surface_parcellation_template: /cpac_templates/Schaefer2018_200Parcels_17Networks_order.dlabel.nii
 timeseries_extraction:
-  connectivity_matrix:
-    measure:
-    - Pearson
-    using:
-    - AFNI
   realignment: ROI_to_func
   run: true
   tse_roi_paths:

--- a/configs/p057_base-ccs_perturb-abcd_step-functional-masking_conn-afni_nuisance-false.yml
+++ b/configs/p057_base-ccs_perturb-abcd_step-functional-masking_conn-afni_nuisance-false.yml
@@ -148,7 +148,7 @@ functional_preproc:
       bold_ref: null
       brain_mask: $FSLDIR/data/standard/MNI152_T1_${resolution_for_anat}_brain_mask.nii.gz
       brain_probseg: $FSLDIR/data/standard/MNI152_T1_${resolution_for_anat}_brain_mask.nii.gz
-    apply_func_mask_in_native_space: false
+    apply_func_mask_in_native_space: true
     run: true
     using:
     - Anatomical_Resampled
@@ -292,6 +292,7 @@ nuisance_corrections:
     - false
     space: native
 pipeline_setup:
+  freesurfer_dir: /ocean/projects/med220004p/trogers1/many_pipelines/freesurfer/outputs/ABCD_all_subjects
   Amazon-AWS:
     aws_output_bucket_credentials: null
     s3_encryption: false
@@ -342,7 +343,7 @@ pipeline_setup:
     random_seed: null
   working_directory:
     path: /outputs/working
-    remove_working_dir: true
+    remove_working_dir: false
 post_processing:
   spatial_smoothing:
     fwhm:
@@ -436,7 +437,6 @@ registration_workflows:
         identity_matrix: $FSLDIR/etc/flirtsch/ident.mat
         interpolation: trilinear
         ref_mask: $FSLDIR/data/standard/MNI152_T1_${resolution_for_anat}_brain_mask_dil.nii.gz
-        ref_mask_res-2: $FSLDIR/data/standard/MNI152_T1_2mm_brain_mask_dil.nii.gz
         ref_resolution: 2mm
       using:
       - FSL
@@ -527,8 +527,6 @@ registration_workflows:
           func_reg_input_volume: 7
         input:
         - Selected_Functional_Volume
-        reg_with_skull: false
-      input: brain
       interpolation: trilinear
       run: true
       using: FSL
@@ -631,7 +629,7 @@ surface_analysis:
   freesurfer:
     ingress_reconall: true
     reconall_args: -clean-bm -gcut
-    run_reconall: true
+    run_reconall: false
   post_freesurfer:
     fmri_res: 2
     freesurfer_labels: /opt/dcan-tools/pipeline/global/config/FreeSurferAllLut.txt
@@ -649,11 +647,6 @@ surface_analysis:
     run: false
     surface_parcellation_template: /cpac_templates/Schaefer2018_200Parcels_17Networks_order.dlabel.nii
 timeseries_extraction:
-  connectivity_matrix:
-    measure:
-    - Pearson
-    using:
-    - AFNI
   realignment: ROI_to_func
   run: true
   tse_roi_paths:

--- a/configs/p058_base-ccs_perturb-abcd_step-functional-masking_conn-nilearn_nuisance-true.yml
+++ b/configs/p058_base-ccs_perturb-abcd_step-functional-masking_conn-nilearn_nuisance-true.yml
@@ -148,7 +148,7 @@ functional_preproc:
       bold_ref: null
       brain_mask: $FSLDIR/data/standard/MNI152_T1_${resolution_for_anat}_brain_mask.nii.gz
       brain_probseg: $FSLDIR/data/standard/MNI152_T1_${resolution_for_anat}_brain_mask.nii.gz
-    apply_func_mask_in_native_space: false
+    apply_func_mask_in_native_space: true
     run: true
     using:
     - Anatomical_Resampled
@@ -266,7 +266,7 @@ nuisance_corrections:
         - global_signal
         Name: default
       run: false
-    lateral_ventricles_mask: $FSLDIR/data/atlases/HarvardOxford/HarvardOxford-lateral-ventricles-thr25-2mm.nii.gz
+    lateral_ventricles_mask: None
     regressor_masks:
       erode_anatomical_brain_mask:
         brain_erosion_mm: null
@@ -292,6 +292,7 @@ nuisance_corrections:
     - true
     space: native
 pipeline_setup:
+  freesurfer_dir: /ocean/projects/med220004p/trogers1/many_pipelines/freesurfer/outputs/ABCD_all_subjects
   Amazon-AWS:
     aws_output_bucket_credentials: null
     s3_encryption: false
@@ -342,7 +343,7 @@ pipeline_setup:
     random_seed: null
   working_directory:
     path: /outputs/working
-    remove_working_dir: true
+    remove_working_dir: false
 post_processing:
   spatial_smoothing:
     fwhm:
@@ -436,7 +437,6 @@ registration_workflows:
         identity_matrix: $FSLDIR/etc/flirtsch/ident.mat
         interpolation: trilinear
         ref_mask: $FSLDIR/data/standard/MNI152_T1_${resolution_for_anat}_brain_mask_dil.nii.gz
-        ref_mask_res-2: $FSLDIR/data/standard/MNI152_T1_2mm_brain_mask_dil.nii.gz
         ref_resolution: 2mm
       using:
       - FSL
@@ -527,8 +527,6 @@ registration_workflows:
           func_reg_input_volume: 7
         input:
         - Selected_Functional_Volume
-        reg_with_skull: false
-      input: brain
       interpolation: trilinear
       run: true
       using: FSL
@@ -592,7 +590,7 @@ segmentation:
         GM_path: $priors_path/avg152T1_gray_bin.nii.gz
         WM_path: $priors_path/avg152T1_white_bin.nii.gz
         priors_path: $FSLDIR/data/standard/tissuepriors/2mm
-        run: true
+        run: false
     FreeSurfer:
       CSF_label:
       - 4
@@ -631,7 +629,7 @@ surface_analysis:
   freesurfer:
     ingress_reconall: true
     reconall_args: -clean-bm -gcut
-    run_reconall: true
+    run_reconall: false
   post_freesurfer:
     fmri_res: 2
     freesurfer_labels: /opt/dcan-tools/pipeline/global/config/FreeSurferAllLut.txt
@@ -649,11 +647,6 @@ surface_analysis:
     run: false
     surface_parcellation_template: /cpac_templates/Schaefer2018_200Parcels_17Networks_order.dlabel.nii
 timeseries_extraction:
-  connectivity_matrix:
-    measure:
-    - Pearson
-    using:
-    - Nilearn
   realignment: ROI_to_func
   run: true
   tse_roi_paths:

--- a/configs/p059_base-ccs_perturb-abcd_step-functional-masking_conn-nilearn_nuisance-false.yml
+++ b/configs/p059_base-ccs_perturb-abcd_step-functional-masking_conn-nilearn_nuisance-false.yml
@@ -148,7 +148,7 @@ functional_preproc:
       bold_ref: null
       brain_mask: $FSLDIR/data/standard/MNI152_T1_${resolution_for_anat}_brain_mask.nii.gz
       brain_probseg: $FSLDIR/data/standard/MNI152_T1_${resolution_for_anat}_brain_mask.nii.gz
-    apply_func_mask_in_native_space: false
+    apply_func_mask_in_native_space: true
     run: true
     using:
     - Anatomical_Resampled
@@ -292,6 +292,7 @@ nuisance_corrections:
     - false
     space: native
 pipeline_setup:
+  freesurfer_dir: /ocean/projects/med220004p/trogers1/many_pipelines/freesurfer/outputs/ABCD_all_subjects
   Amazon-AWS:
     aws_output_bucket_credentials: null
     s3_encryption: false
@@ -342,7 +343,7 @@ pipeline_setup:
     random_seed: null
   working_directory:
     path: /outputs/working
-    remove_working_dir: true
+    remove_working_dir: false
 post_processing:
   spatial_smoothing:
     fwhm:
@@ -436,7 +437,6 @@ registration_workflows:
         identity_matrix: $FSLDIR/etc/flirtsch/ident.mat
         interpolation: trilinear
         ref_mask: $FSLDIR/data/standard/MNI152_T1_${resolution_for_anat}_brain_mask_dil.nii.gz
-        ref_mask_res-2: $FSLDIR/data/standard/MNI152_T1_2mm_brain_mask_dil.nii.gz
         ref_resolution: 2mm
       using:
       - FSL
@@ -527,8 +527,6 @@ registration_workflows:
           func_reg_input_volume: 7
         input:
         - Selected_Functional_Volume
-        reg_with_skull: false
-      input: brain
       interpolation: trilinear
       run: true
       using: FSL
@@ -631,7 +629,7 @@ surface_analysis:
   freesurfer:
     ingress_reconall: true
     reconall_args: -clean-bm -gcut
-    run_reconall: true
+    run_reconall: false
   post_freesurfer:
     fmri_res: 2
     freesurfer_labels: /opt/dcan-tools/pipeline/global/config/FreeSurferAllLut.txt
@@ -649,11 +647,6 @@ surface_analysis:
     run: false
     surface_parcellation_template: /cpac_templates/Schaefer2018_200Parcels_17Networks_order.dlabel.nii
 timeseries_extraction:
-  connectivity_matrix:
-    measure:
-    - Pearson
-    using:
-    - Nilearn
   realignment: ROI_to_func
   run: true
   tse_roi_paths:

--- a/configs/p060_base-ccs_perturb-abcd_step-functional-registration_conn-afni_nuisance-true.yml
+++ b/configs/p060_base-ccs_perturb-abcd_step-functional-registration_conn-afni_nuisance-true.yml
@@ -292,6 +292,7 @@ nuisance_corrections:
     - true
     space: native
 pipeline_setup:
+  freesurfer_dir: /ocean/projects/med220004p/trogers1/many_pipelines/freesurfer/outputs/ABCD_all_subjects
   Amazon-AWS:
     aws_output_bucket_credentials: null
     s3_encryption: false
@@ -342,7 +343,7 @@ pipeline_setup:
     random_seed: null
   working_directory:
     path: /outputs/working
-    remove_working_dir: true
+    remove_working_dir: false
 post_processing:
   spatial_smoothing:
     fwhm:
@@ -436,7 +437,6 @@ registration_workflows:
         identity_matrix: $FSLDIR/etc/flirtsch/ident.mat
         interpolation: trilinear
         ref_mask: $FSLDIR/data/standard/MNI152_T1_${resolution_for_anat}_brain_mask_dil.nii.gz
-        ref_mask_res-2: $FSLDIR/data/standard/MNI152_T1_2mm_brain_mask_dil.nii.gz
         ref_resolution: 2mm
       using:
       - FSL
@@ -527,8 +527,6 @@ registration_workflows:
           func_reg_input_volume: 0
         input:
         - Selected_Functional_Volume
-        reg_with_skull: true
-      input: brain
       interpolation: spline
       run: true
       using: FSL
@@ -631,7 +629,7 @@ surface_analysis:
   freesurfer:
     ingress_reconall: true
     reconall_args: -clean-bm -gcut
-    run_reconall: true
+    run_reconall: false
   post_freesurfer:
     fmri_res: 2
     freesurfer_labels: /opt/dcan-tools/pipeline/global/config/FreeSurferAllLut.txt
@@ -649,11 +647,6 @@ surface_analysis:
     run: false
     surface_parcellation_template: /cpac_templates/Schaefer2018_200Parcels_17Networks_order.dlabel.nii
 timeseries_extraction:
-  connectivity_matrix:
-    measure:
-    - Pearson
-    using:
-    - AFNI
   realignment: ROI_to_func
   run: true
   tse_roi_paths:

--- a/configs/p061_base-ccs_perturb-abcd_step-functional-registration_conn-afni_nuisance-false.yml
+++ b/configs/p061_base-ccs_perturb-abcd_step-functional-registration_conn-afni_nuisance-false.yml
@@ -292,6 +292,7 @@ nuisance_corrections:
     - false
     space: native
 pipeline_setup:
+  freesurfer_dir: /ocean/projects/med220004p/trogers1/many_pipelines/freesurfer/outputs/ABCD_all_subjects
   Amazon-AWS:
     aws_output_bucket_credentials: null
     s3_encryption: false
@@ -342,7 +343,7 @@ pipeline_setup:
     random_seed: null
   working_directory:
     path: /outputs/working
-    remove_working_dir: true
+    remove_working_dir: false
 post_processing:
   spatial_smoothing:
     fwhm:
@@ -436,7 +437,6 @@ registration_workflows:
         identity_matrix: $FSLDIR/etc/flirtsch/ident.mat
         interpolation: trilinear
         ref_mask: $FSLDIR/data/standard/MNI152_T1_${resolution_for_anat}_brain_mask_dil.nii.gz
-        ref_mask_res-2: $FSLDIR/data/standard/MNI152_T1_2mm_brain_mask_dil.nii.gz
         ref_resolution: 2mm
       using:
       - FSL
@@ -527,8 +527,6 @@ registration_workflows:
           func_reg_input_volume: 0
         input:
         - Selected_Functional_Volume
-        reg_with_skull: true
-      input: brain
       interpolation: spline
       run: true
       using: FSL
@@ -631,7 +629,7 @@ surface_analysis:
   freesurfer:
     ingress_reconall: true
     reconall_args: -clean-bm -gcut
-    run_reconall: true
+    run_reconall: false
   post_freesurfer:
     fmri_res: 2
     freesurfer_labels: /opt/dcan-tools/pipeline/global/config/FreeSurferAllLut.txt
@@ -649,11 +647,6 @@ surface_analysis:
     run: false
     surface_parcellation_template: /cpac_templates/Schaefer2018_200Parcels_17Networks_order.dlabel.nii
 timeseries_extraction:
-  connectivity_matrix:
-    measure:
-    - Pearson
-    using:
-    - AFNI
   realignment: ROI_to_func
   run: true
   tse_roi_paths:

--- a/configs/p062_base-ccs_perturb-abcd_step-functional-registration_conn-nilearn_nuisance-true.yml
+++ b/configs/p062_base-ccs_perturb-abcd_step-functional-registration_conn-nilearn_nuisance-true.yml
@@ -292,6 +292,7 @@ nuisance_corrections:
     - true
     space: native
 pipeline_setup:
+  freesurfer_dir: /ocean/projects/med220004p/trogers1/many_pipelines/freesurfer/outputs/ABCD_all_subjects
   Amazon-AWS:
     aws_output_bucket_credentials: null
     s3_encryption: false
@@ -342,7 +343,7 @@ pipeline_setup:
     random_seed: null
   working_directory:
     path: /outputs/working
-    remove_working_dir: true
+    remove_working_dir: false
 post_processing:
   spatial_smoothing:
     fwhm:
@@ -436,7 +437,6 @@ registration_workflows:
         identity_matrix: $FSLDIR/etc/flirtsch/ident.mat
         interpolation: trilinear
         ref_mask: $FSLDIR/data/standard/MNI152_T1_${resolution_for_anat}_brain_mask_dil.nii.gz
-        ref_mask_res-2: $FSLDIR/data/standard/MNI152_T1_2mm_brain_mask_dil.nii.gz
         ref_resolution: 2mm
       using:
       - FSL
@@ -527,8 +527,6 @@ registration_workflows:
           func_reg_input_volume: 0
         input:
         - Selected_Functional_Volume
-        reg_with_skull: true
-      input: brain
       interpolation: spline
       run: true
       using: FSL
@@ -631,7 +629,7 @@ surface_analysis:
   freesurfer:
     ingress_reconall: true
     reconall_args: -clean-bm -gcut
-    run_reconall: true
+    run_reconall: false
   post_freesurfer:
     fmri_res: 2
     freesurfer_labels: /opt/dcan-tools/pipeline/global/config/FreeSurferAllLut.txt
@@ -649,11 +647,6 @@ surface_analysis:
     run: false
     surface_parcellation_template: /cpac_templates/Schaefer2018_200Parcels_17Networks_order.dlabel.nii
 timeseries_extraction:
-  connectivity_matrix:
-    measure:
-    - Pearson
-    using:
-    - Nilearn
   realignment: ROI_to_func
   run: true
   tse_roi_paths:

--- a/configs/p063_base-ccs_perturb-abcd_step-functional-registration_conn-nilearn_nuisance-false.yml
+++ b/configs/p063_base-ccs_perturb-abcd_step-functional-registration_conn-nilearn_nuisance-false.yml
@@ -292,6 +292,7 @@ nuisance_corrections:
     - false
     space: native
 pipeline_setup:
+  freesurfer_dir: /ocean/projects/med220004p/trogers1/many_pipelines/freesurfer/outputs/ABCD_all_subjects
   Amazon-AWS:
     aws_output_bucket_credentials: null
     s3_encryption: false
@@ -342,7 +343,7 @@ pipeline_setup:
     random_seed: null
   working_directory:
     path: /outputs/working
-    remove_working_dir: true
+    remove_working_dir: false
 post_processing:
   spatial_smoothing:
     fwhm:
@@ -436,7 +437,6 @@ registration_workflows:
         identity_matrix: $FSLDIR/etc/flirtsch/ident.mat
         interpolation: trilinear
         ref_mask: $FSLDIR/data/standard/MNI152_T1_${resolution_for_anat}_brain_mask_dil.nii.gz
-        ref_mask_res-2: $FSLDIR/data/standard/MNI152_T1_2mm_brain_mask_dil.nii.gz
         ref_resolution: 2mm
       using:
       - FSL
@@ -527,8 +527,6 @@ registration_workflows:
           func_reg_input_volume: 0
         input:
         - Selected_Functional_Volume
-        reg_with_skull: true
-      input: brain
       interpolation: spline
       run: true
       using: FSL
@@ -631,7 +629,7 @@ surface_analysis:
   freesurfer:
     ingress_reconall: true
     reconall_args: -clean-bm -gcut
-    run_reconall: true
+    run_reconall: false
   post_freesurfer:
     fmri_res: 2
     freesurfer_labels: /opt/dcan-tools/pipeline/global/config/FreeSurferAllLut.txt
@@ -649,11 +647,6 @@ surface_analysis:
     run: false
     surface_parcellation_template: /cpac_templates/Schaefer2018_200Parcels_17Networks_order.dlabel.nii
 timeseries_extraction:
-  connectivity_matrix:
-    measure:
-    - Pearson
-    using:
-    - Nilearn
   realignment: ROI_to_func
   run: true
   tse_roi_paths:

--- a/configs/p064_base-ccs_perturb-rbc_step-structural-masking_conn-afni_nuisance-true.yml
+++ b/configs/p064_base-ccs_perturb-rbc_step-structural-masking_conn-afni_nuisance-true.yml
@@ -290,6 +290,7 @@ nuisance_corrections:
     - true
     space: native
 pipeline_setup:
+  freesurfer_dir: /ocean/projects/med220004p/trogers1/many_pipelines/freesurfer/outputs/ABCD_all_subjects
   Amazon-AWS:
     aws_output_bucket_credentials: null
     s3_encryption: false
@@ -340,7 +341,7 @@ pipeline_setup:
     random_seed: null
   working_directory:
     path: /outputs/working
-    remove_working_dir: true
+    remove_working_dir: false
 post_processing:
   spatial_smoothing:
     fwhm:
@@ -434,7 +435,6 @@ registration_workflows:
         identity_matrix: $FSLDIR/etc/flirtsch/ident.mat
         interpolation: trilinear
         ref_mask: $FSLDIR/data/standard/MNI152_T1_${resolution_for_anat}_brain_mask_dil.nii.gz
-        ref_mask_res-2: $FSLDIR/data/standard/MNI152_T1_2mm_brain_mask_dil.nii.gz
         ref_resolution: 2mm
       using:
       - FSL
@@ -525,8 +525,6 @@ registration_workflows:
           func_reg_input_volume: 7
         input:
         - Selected_Functional_Volume
-        reg_with_skull: false
-      input: brain
       interpolation: trilinear
       run: true
       using: FSL
@@ -629,7 +627,7 @@ surface_analysis:
   freesurfer:
     ingress_reconall: true
     reconall_args: -clean-bm -gcut
-    run_reconall: true
+    run_reconall: false
   post_freesurfer:
     fmri_res: 2
     freesurfer_labels: /opt/dcan-tools/pipeline/global/config/FreeSurferAllLut.txt
@@ -647,11 +645,6 @@ surface_analysis:
     run: false
     surface_parcellation_template: /cpac_templates/Schaefer2018_200Parcels_17Networks_order.dlabel.nii
 timeseries_extraction:
-  connectivity_matrix:
-    measure:
-    - Pearson
-    using:
-    - AFNI
   realignment: ROI_to_func
   run: true
   tse_roi_paths:

--- a/configs/p065_base-ccs_perturb-rbc_step-structural-masking_conn-afni_nuisance-false.yml
+++ b/configs/p065_base-ccs_perturb-rbc_step-structural-masking_conn-afni_nuisance-false.yml
@@ -290,6 +290,7 @@ nuisance_corrections:
     - false
     space: native
 pipeline_setup:
+  freesurfer_dir: /ocean/projects/med220004p/trogers1/many_pipelines/freesurfer/outputs/ABCD_all_subjects
   Amazon-AWS:
     aws_output_bucket_credentials: null
     s3_encryption: false
@@ -340,7 +341,7 @@ pipeline_setup:
     random_seed: null
   working_directory:
     path: /outputs/working
-    remove_working_dir: true
+    remove_working_dir: false
 post_processing:
   spatial_smoothing:
     fwhm:
@@ -434,7 +435,6 @@ registration_workflows:
         identity_matrix: $FSLDIR/etc/flirtsch/ident.mat
         interpolation: trilinear
         ref_mask: $FSLDIR/data/standard/MNI152_T1_${resolution_for_anat}_brain_mask_dil.nii.gz
-        ref_mask_res-2: $FSLDIR/data/standard/MNI152_T1_2mm_brain_mask_dil.nii.gz
         ref_resolution: 2mm
       using:
       - FSL
@@ -525,8 +525,6 @@ registration_workflows:
           func_reg_input_volume: 7
         input:
         - Selected_Functional_Volume
-        reg_with_skull: false
-      input: brain
       interpolation: trilinear
       run: true
       using: FSL
@@ -629,7 +627,7 @@ surface_analysis:
   freesurfer:
     ingress_reconall: true
     reconall_args: -clean-bm -gcut
-    run_reconall: true
+    run_reconall: false
   post_freesurfer:
     fmri_res: 2
     freesurfer_labels: /opt/dcan-tools/pipeline/global/config/FreeSurferAllLut.txt
@@ -647,11 +645,6 @@ surface_analysis:
     run: false
     surface_parcellation_template: /cpac_templates/Schaefer2018_200Parcels_17Networks_order.dlabel.nii
 timeseries_extraction:
-  connectivity_matrix:
-    measure:
-    - Pearson
-    using:
-    - AFNI
   realignment: ROI_to_func
   run: true
   tse_roi_paths:

--- a/configs/p066_base-ccs_perturb-rbc_step-structural-masking_conn-nilearn_nuisance-true.yml
+++ b/configs/p066_base-ccs_perturb-rbc_step-structural-masking_conn-nilearn_nuisance-true.yml
@@ -290,6 +290,7 @@ nuisance_corrections:
     - true
     space: native
 pipeline_setup:
+  freesurfer_dir: /ocean/projects/med220004p/trogers1/many_pipelines/freesurfer/outputs/ABCD_all_subjects
   Amazon-AWS:
     aws_output_bucket_credentials: null
     s3_encryption: false
@@ -340,7 +341,7 @@ pipeline_setup:
     random_seed: null
   working_directory:
     path: /outputs/working
-    remove_working_dir: true
+    remove_working_dir: false
 post_processing:
   spatial_smoothing:
     fwhm:
@@ -434,7 +435,6 @@ registration_workflows:
         identity_matrix: $FSLDIR/etc/flirtsch/ident.mat
         interpolation: trilinear
         ref_mask: $FSLDIR/data/standard/MNI152_T1_${resolution_for_anat}_brain_mask_dil.nii.gz
-        ref_mask_res-2: $FSLDIR/data/standard/MNI152_T1_2mm_brain_mask_dil.nii.gz
         ref_resolution: 2mm
       using:
       - FSL
@@ -525,8 +525,6 @@ registration_workflows:
           func_reg_input_volume: 7
         input:
         - Selected_Functional_Volume
-        reg_with_skull: false
-      input: brain
       interpolation: trilinear
       run: true
       using: FSL
@@ -629,7 +627,7 @@ surface_analysis:
   freesurfer:
     ingress_reconall: true
     reconall_args: -clean-bm -gcut
-    run_reconall: true
+    run_reconall: false
   post_freesurfer:
     fmri_res: 2
     freesurfer_labels: /opt/dcan-tools/pipeline/global/config/FreeSurferAllLut.txt
@@ -647,11 +645,6 @@ surface_analysis:
     run: false
     surface_parcellation_template: /cpac_templates/Schaefer2018_200Parcels_17Networks_order.dlabel.nii
 timeseries_extraction:
-  connectivity_matrix:
-    measure:
-    - Pearson
-    using:
-    - Nilearn
   realignment: ROI_to_func
   run: true
   tse_roi_paths:

--- a/configs/p067_base-ccs_perturb-rbc_step-structural-masking_conn-nilearn_nuisance-false.yml
+++ b/configs/p067_base-ccs_perturb-rbc_step-structural-masking_conn-nilearn_nuisance-false.yml
@@ -290,6 +290,7 @@ nuisance_corrections:
     - false
     space: native
 pipeline_setup:
+  freesurfer_dir: /ocean/projects/med220004p/trogers1/many_pipelines/freesurfer/outputs/ABCD_all_subjects
   Amazon-AWS:
     aws_output_bucket_credentials: null
     s3_encryption: false
@@ -340,7 +341,7 @@ pipeline_setup:
     random_seed: null
   working_directory:
     path: /outputs/working
-    remove_working_dir: true
+    remove_working_dir: false
 post_processing:
   spatial_smoothing:
     fwhm:
@@ -434,7 +435,6 @@ registration_workflows:
         identity_matrix: $FSLDIR/etc/flirtsch/ident.mat
         interpolation: trilinear
         ref_mask: $FSLDIR/data/standard/MNI152_T1_${resolution_for_anat}_brain_mask_dil.nii.gz
-        ref_mask_res-2: $FSLDIR/data/standard/MNI152_T1_2mm_brain_mask_dil.nii.gz
         ref_resolution: 2mm
       using:
       - FSL
@@ -525,8 +525,6 @@ registration_workflows:
           func_reg_input_volume: 7
         input:
         - Selected_Functional_Volume
-        reg_with_skull: false
-      input: brain
       interpolation: trilinear
       run: true
       using: FSL
@@ -629,7 +627,7 @@ surface_analysis:
   freesurfer:
     ingress_reconall: true
     reconall_args: -clean-bm -gcut
-    run_reconall: true
+    run_reconall: false
   post_freesurfer:
     fmri_res: 2
     freesurfer_labels: /opt/dcan-tools/pipeline/global/config/FreeSurferAllLut.txt
@@ -647,11 +645,6 @@ surface_analysis:
     run: false
     surface_parcellation_template: /cpac_templates/Schaefer2018_200Parcels_17Networks_order.dlabel.nii
 timeseries_extraction:
-  connectivity_matrix:
-    measure:
-    - Pearson
-    using:
-    - Nilearn
   realignment: ROI_to_func
   run: true
   tse_roi_paths:

--- a/configs/p068_base-ccs_perturb-rbc_step-structural-registration_conn-afni_nuisance-true.yml
+++ b/configs/p068_base-ccs_perturb-rbc_step-structural-registration_conn-afni_nuisance-true.yml
@@ -292,6 +292,7 @@ nuisance_corrections:
     - true
     space: native
 pipeline_setup:
+  freesurfer_dir: /ocean/projects/med220004p/trogers1/many_pipelines/freesurfer/outputs/ABCD_all_subjects
   Amazon-AWS:
     aws_output_bucket_credentials: null
     s3_encryption: false
@@ -342,7 +343,7 @@ pipeline_setup:
     random_seed: null
   working_directory:
     path: /outputs/working
-    remove_working_dir: true
+    remove_working_dir: false
 post_processing:
   spatial_smoothing:
     fwhm:
@@ -436,7 +437,6 @@ registration_workflows:
         identity_matrix: $FSLDIR/etc/flirtsch/ident.mat
         interpolation: sinc
         ref_mask: null
-        ref_mask_res-2: null
         ref_resolution: 2mm
       using:
       - ANTS
@@ -527,8 +527,6 @@ registration_workflows:
           func_reg_input_volume: 7
         input:
         - Selected_Functional_Volume
-        reg_with_skull: false
-      input: brain
       interpolation: trilinear
       run: true
       using: FSL
@@ -631,7 +629,7 @@ surface_analysis:
   freesurfer:
     ingress_reconall: true
     reconall_args: -clean-bm -gcut
-    run_reconall: true
+    run_reconall: false
   post_freesurfer:
     fmri_res: 2
     freesurfer_labels: /opt/dcan-tools/pipeline/global/config/FreeSurferAllLut.txt
@@ -649,11 +647,6 @@ surface_analysis:
     run: false
     surface_parcellation_template: /cpac_templates/Schaefer2018_200Parcels_17Networks_order.dlabel.nii
 timeseries_extraction:
-  connectivity_matrix:
-    measure:
-    - Pearson
-    using:
-    - AFNI
   realignment: ROI_to_func
   run: true
   tse_roi_paths:

--- a/configs/p069_base-ccs_perturb-rbc_step-structural-registration_conn-afni_nuisance-false.yml
+++ b/configs/p069_base-ccs_perturb-rbc_step-structural-registration_conn-afni_nuisance-false.yml
@@ -292,6 +292,7 @@ nuisance_corrections:
     - false
     space: native
 pipeline_setup:
+  freesurfer_dir: /ocean/projects/med220004p/trogers1/many_pipelines/freesurfer/outputs/ABCD_all_subjects
   Amazon-AWS:
     aws_output_bucket_credentials: null
     s3_encryption: false
@@ -342,7 +343,7 @@ pipeline_setup:
     random_seed: null
   working_directory:
     path: /outputs/working
-    remove_working_dir: true
+    remove_working_dir: false
 post_processing:
   spatial_smoothing:
     fwhm:
@@ -436,7 +437,6 @@ registration_workflows:
         identity_matrix: $FSLDIR/etc/flirtsch/ident.mat
         interpolation: sinc
         ref_mask: null
-        ref_mask_res-2: null
         ref_resolution: 2mm
       using:
       - ANTS
@@ -527,8 +527,6 @@ registration_workflows:
           func_reg_input_volume: 7
         input:
         - Selected_Functional_Volume
-        reg_with_skull: false
-      input: brain
       interpolation: trilinear
       run: true
       using: FSL
@@ -631,7 +629,7 @@ surface_analysis:
   freesurfer:
     ingress_reconall: true
     reconall_args: -clean-bm -gcut
-    run_reconall: true
+    run_reconall: false
   post_freesurfer:
     fmri_res: 2
     freesurfer_labels: /opt/dcan-tools/pipeline/global/config/FreeSurferAllLut.txt
@@ -649,11 +647,6 @@ surface_analysis:
     run: false
     surface_parcellation_template: /cpac_templates/Schaefer2018_200Parcels_17Networks_order.dlabel.nii
 timeseries_extraction:
-  connectivity_matrix:
-    measure:
-    - Pearson
-    using:
-    - AFNI
   realignment: ROI_to_func
   run: true
   tse_roi_paths:

--- a/configs/p070_base-ccs_perturb-rbc_step-structural-registration_conn-nilearn_nuisance-true.yml
+++ b/configs/p070_base-ccs_perturb-rbc_step-structural-registration_conn-nilearn_nuisance-true.yml
@@ -292,6 +292,7 @@ nuisance_corrections:
     - true
     space: native
 pipeline_setup:
+  freesurfer_dir: /ocean/projects/med220004p/trogers1/many_pipelines/freesurfer/outputs/ABCD_all_subjects
   Amazon-AWS:
     aws_output_bucket_credentials: null
     s3_encryption: false
@@ -342,7 +343,7 @@ pipeline_setup:
     random_seed: null
   working_directory:
     path: /outputs/working
-    remove_working_dir: true
+    remove_working_dir: false
 post_processing:
   spatial_smoothing:
     fwhm:
@@ -436,7 +437,6 @@ registration_workflows:
         identity_matrix: $FSLDIR/etc/flirtsch/ident.mat
         interpolation: sinc
         ref_mask: null
-        ref_mask_res-2: null
         ref_resolution: 2mm
       using:
       - ANTS
@@ -527,8 +527,6 @@ registration_workflows:
           func_reg_input_volume: 7
         input:
         - Selected_Functional_Volume
-        reg_with_skull: false
-      input: brain
       interpolation: trilinear
       run: true
       using: FSL
@@ -631,7 +629,7 @@ surface_analysis:
   freesurfer:
     ingress_reconall: true
     reconall_args: -clean-bm -gcut
-    run_reconall: true
+    run_reconall: false
   post_freesurfer:
     fmri_res: 2
     freesurfer_labels: /opt/dcan-tools/pipeline/global/config/FreeSurferAllLut.txt
@@ -649,11 +647,6 @@ surface_analysis:
     run: false
     surface_parcellation_template: /cpac_templates/Schaefer2018_200Parcels_17Networks_order.dlabel.nii
 timeseries_extraction:
-  connectivity_matrix:
-    measure:
-    - Pearson
-    using:
-    - Nilearn
   realignment: ROI_to_func
   run: true
   tse_roi_paths:

--- a/configs/p071_base-ccs_perturb-rbc_step-structural-registration_conn-nilearn_nuisance-false.yml
+++ b/configs/p071_base-ccs_perturb-rbc_step-structural-registration_conn-nilearn_nuisance-false.yml
@@ -292,6 +292,7 @@ nuisance_corrections:
     - false
     space: native
 pipeline_setup:
+  freesurfer_dir: /ocean/projects/med220004p/trogers1/many_pipelines/freesurfer/outputs/ABCD_all_subjects
   Amazon-AWS:
     aws_output_bucket_credentials: null
     s3_encryption: false
@@ -342,7 +343,7 @@ pipeline_setup:
     random_seed: null
   working_directory:
     path: /outputs/working
-    remove_working_dir: true
+    remove_working_dir: false
 post_processing:
   spatial_smoothing:
     fwhm:
@@ -436,7 +437,6 @@ registration_workflows:
         identity_matrix: $FSLDIR/etc/flirtsch/ident.mat
         interpolation: sinc
         ref_mask: null
-        ref_mask_res-2: null
         ref_resolution: 2mm
       using:
       - ANTS
@@ -527,8 +527,6 @@ registration_workflows:
           func_reg_input_volume: 7
         input:
         - Selected_Functional_Volume
-        reg_with_skull: false
-      input: brain
       interpolation: trilinear
       run: true
       using: FSL
@@ -631,7 +629,7 @@ surface_analysis:
   freesurfer:
     ingress_reconall: true
     reconall_args: -clean-bm -gcut
-    run_reconall: true
+    run_reconall: false
   post_freesurfer:
     fmri_res: 2
     freesurfer_labels: /opt/dcan-tools/pipeline/global/config/FreeSurferAllLut.txt
@@ -649,11 +647,6 @@ surface_analysis:
     run: false
     surface_parcellation_template: /cpac_templates/Schaefer2018_200Parcels_17Networks_order.dlabel.nii
 timeseries_extraction:
-  connectivity_matrix:
-    measure:
-    - Pearson
-    using:
-    - Nilearn
   realignment: ROI_to_func
   run: true
   tse_roi_paths:

--- a/configs/p072_base-ccs_perturb-rbc_step-functional-masking_conn-afni_nuisance-true.yml
+++ b/configs/p072_base-ccs_perturb-rbc_step-functional-masking_conn-afni_nuisance-true.yml
@@ -292,6 +292,7 @@ nuisance_corrections:
     - true
     space: native
 pipeline_setup:
+  freesurfer_dir: /ocean/projects/med220004p/trogers1/many_pipelines/freesurfer/outputs/ABCD_all_subjects
   Amazon-AWS:
     aws_output_bucket_credentials: null
     s3_encryption: false
@@ -342,7 +343,7 @@ pipeline_setup:
     random_seed: null
   working_directory:
     path: /outputs/working
-    remove_working_dir: true
+    remove_working_dir: false
 post_processing:
   spatial_smoothing:
     fwhm:
@@ -436,7 +437,6 @@ registration_workflows:
         identity_matrix: $FSLDIR/etc/flirtsch/ident.mat
         interpolation: trilinear
         ref_mask: $FSLDIR/data/standard/MNI152_T1_${resolution_for_anat}_brain_mask_dil.nii.gz
-        ref_mask_res-2: $FSLDIR/data/standard/MNI152_T1_2mm_brain_mask_dil.nii.gz
         ref_resolution: 2mm
       using:
       - FSL
@@ -527,8 +527,6 @@ registration_workflows:
           func_reg_input_volume: 7
         input:
         - Selected_Functional_Volume
-        reg_with_skull: false
-      input: brain
       interpolation: trilinear
       run: true
       using: FSL
@@ -631,7 +629,7 @@ surface_analysis:
   freesurfer:
     ingress_reconall: true
     reconall_args: -clean-bm -gcut
-    run_reconall: true
+    run_reconall: false
   post_freesurfer:
     fmri_res: 2
     freesurfer_labels: /opt/dcan-tools/pipeline/global/config/FreeSurferAllLut.txt
@@ -649,11 +647,6 @@ surface_analysis:
     run: false
     surface_parcellation_template: /cpac_templates/Schaefer2018_200Parcels_17Networks_order.dlabel.nii
 timeseries_extraction:
-  connectivity_matrix:
-    measure:
-    - Pearson
-    using:
-    - AFNI
   realignment: ROI_to_func
   run: true
   tse_roi_paths:

--- a/configs/p073_base-ccs_perturb-rbc_step-functional-masking_conn-afni_nuisance-false.yml
+++ b/configs/p073_base-ccs_perturb-rbc_step-functional-masking_conn-afni_nuisance-false.yml
@@ -292,6 +292,7 @@ nuisance_corrections:
     - false
     space: native
 pipeline_setup:
+  freesurfer_dir: /ocean/projects/med220004p/trogers1/many_pipelines/freesurfer/outputs/ABCD_all_subjects
   Amazon-AWS:
     aws_output_bucket_credentials: null
     s3_encryption: false
@@ -342,7 +343,7 @@ pipeline_setup:
     random_seed: null
   working_directory:
     path: /outputs/working
-    remove_working_dir: true
+    remove_working_dir: false
 post_processing:
   spatial_smoothing:
     fwhm:
@@ -436,7 +437,6 @@ registration_workflows:
         identity_matrix: $FSLDIR/etc/flirtsch/ident.mat
         interpolation: trilinear
         ref_mask: $FSLDIR/data/standard/MNI152_T1_${resolution_for_anat}_brain_mask_dil.nii.gz
-        ref_mask_res-2: $FSLDIR/data/standard/MNI152_T1_2mm_brain_mask_dil.nii.gz
         ref_resolution: 2mm
       using:
       - FSL
@@ -527,8 +527,6 @@ registration_workflows:
           func_reg_input_volume: 7
         input:
         - Selected_Functional_Volume
-        reg_with_skull: false
-      input: brain
       interpolation: trilinear
       run: true
       using: FSL
@@ -631,7 +629,7 @@ surface_analysis:
   freesurfer:
     ingress_reconall: true
     reconall_args: -clean-bm -gcut
-    run_reconall: true
+    run_reconall: false
   post_freesurfer:
     fmri_res: 2
     freesurfer_labels: /opt/dcan-tools/pipeline/global/config/FreeSurferAllLut.txt
@@ -649,11 +647,6 @@ surface_analysis:
     run: false
     surface_parcellation_template: /cpac_templates/Schaefer2018_200Parcels_17Networks_order.dlabel.nii
 timeseries_extraction:
-  connectivity_matrix:
-    measure:
-    - Pearson
-    using:
-    - AFNI
   realignment: ROI_to_func
   run: true
   tse_roi_paths:

--- a/configs/p074_base-ccs_perturb-rbc_step-functional-masking_conn-nilearn_nuisance-true.yml
+++ b/configs/p074_base-ccs_perturb-rbc_step-functional-masking_conn-nilearn_nuisance-true.yml
@@ -292,6 +292,7 @@ nuisance_corrections:
     - true
     space: native
 pipeline_setup:
+  freesurfer_dir: /ocean/projects/med220004p/trogers1/many_pipelines/freesurfer/outputs/ABCD_all_subjects
   Amazon-AWS:
     aws_output_bucket_credentials: null
     s3_encryption: false
@@ -342,7 +343,7 @@ pipeline_setup:
     random_seed: null
   working_directory:
     path: /outputs/working
-    remove_working_dir: true
+    remove_working_dir: false
 post_processing:
   spatial_smoothing:
     fwhm:
@@ -436,7 +437,6 @@ registration_workflows:
         identity_matrix: $FSLDIR/etc/flirtsch/ident.mat
         interpolation: trilinear
         ref_mask: $FSLDIR/data/standard/MNI152_T1_${resolution_for_anat}_brain_mask_dil.nii.gz
-        ref_mask_res-2: $FSLDIR/data/standard/MNI152_T1_2mm_brain_mask_dil.nii.gz
         ref_resolution: 2mm
       using:
       - FSL
@@ -527,8 +527,6 @@ registration_workflows:
           func_reg_input_volume: 7
         input:
         - Selected_Functional_Volume
-        reg_with_skull: false
-      input: brain
       interpolation: trilinear
       run: true
       using: FSL
@@ -631,7 +629,7 @@ surface_analysis:
   freesurfer:
     ingress_reconall: true
     reconall_args: -clean-bm -gcut
-    run_reconall: true
+    run_reconall: false
   post_freesurfer:
     fmri_res: 2
     freesurfer_labels: /opt/dcan-tools/pipeline/global/config/FreeSurferAllLut.txt
@@ -649,11 +647,6 @@ surface_analysis:
     run: false
     surface_parcellation_template: /cpac_templates/Schaefer2018_200Parcels_17Networks_order.dlabel.nii
 timeseries_extraction:
-  connectivity_matrix:
-    measure:
-    - Pearson
-    using:
-    - Nilearn
   realignment: ROI_to_func
   run: true
   tse_roi_paths:

--- a/configs/p075_base-ccs_perturb-rbc_step-functional-masking_conn-nilearn_nuisance-false.yml
+++ b/configs/p075_base-ccs_perturb-rbc_step-functional-masking_conn-nilearn_nuisance-false.yml
@@ -292,6 +292,7 @@ nuisance_corrections:
     - false
     space: native
 pipeline_setup:
+  freesurfer_dir: /ocean/projects/med220004p/trogers1/many_pipelines/freesurfer/outputs/ABCD_all_subjects
   Amazon-AWS:
     aws_output_bucket_credentials: null
     s3_encryption: false
@@ -342,7 +343,7 @@ pipeline_setup:
     random_seed: null
   working_directory:
     path: /outputs/working
-    remove_working_dir: true
+    remove_working_dir: false
 post_processing:
   spatial_smoothing:
     fwhm:
@@ -436,7 +437,6 @@ registration_workflows:
         identity_matrix: $FSLDIR/etc/flirtsch/ident.mat
         interpolation: trilinear
         ref_mask: $FSLDIR/data/standard/MNI152_T1_${resolution_for_anat}_brain_mask_dil.nii.gz
-        ref_mask_res-2: $FSLDIR/data/standard/MNI152_T1_2mm_brain_mask_dil.nii.gz
         ref_resolution: 2mm
       using:
       - FSL
@@ -527,8 +527,6 @@ registration_workflows:
           func_reg_input_volume: 7
         input:
         - Selected_Functional_Volume
-        reg_with_skull: false
-      input: brain
       interpolation: trilinear
       run: true
       using: FSL
@@ -631,7 +629,7 @@ surface_analysis:
   freesurfer:
     ingress_reconall: true
     reconall_args: -clean-bm -gcut
-    run_reconall: true
+    run_reconall: false
   post_freesurfer:
     fmri_res: 2
     freesurfer_labels: /opt/dcan-tools/pipeline/global/config/FreeSurferAllLut.txt
@@ -649,11 +647,6 @@ surface_analysis:
     run: false
     surface_parcellation_template: /cpac_templates/Schaefer2018_200Parcels_17Networks_order.dlabel.nii
 timeseries_extraction:
-  connectivity_matrix:
-    measure:
-    - Pearson
-    using:
-    - Nilearn
   realignment: ROI_to_func
   run: true
   tse_roi_paths:

--- a/configs/p076_base-ccs_perturb-rbc_step-functional-registration_conn-afni_nuisance-true.yml
+++ b/configs/p076_base-ccs_perturb-rbc_step-functional-registration_conn-afni_nuisance-true.yml
@@ -292,6 +292,7 @@ nuisance_corrections:
     - true
     space: native
 pipeline_setup:
+  freesurfer_dir: /ocean/projects/med220004p/trogers1/many_pipelines/freesurfer/outputs/ABCD_all_subjects
   Amazon-AWS:
     aws_output_bucket_credentials: null
     s3_encryption: false
@@ -342,7 +343,7 @@ pipeline_setup:
     random_seed: null
   working_directory:
     path: /outputs/working
-    remove_working_dir: true
+    remove_working_dir: false
 post_processing:
   spatial_smoothing:
     fwhm:
@@ -436,7 +437,6 @@ registration_workflows:
         identity_matrix: $FSLDIR/etc/flirtsch/ident.mat
         interpolation: trilinear
         ref_mask: $FSLDIR/data/standard/MNI152_T1_${resolution_for_anat}_brain_mask_dil.nii.gz
-        ref_mask_res-2: $FSLDIR/data/standard/MNI152_T1_2mm_brain_mask_dil.nii.gz
         ref_resolution: 2mm
       using:
       - FSL
@@ -527,8 +527,6 @@ registration_workflows:
           func_reg_input_volume: 0
         input:
         - fmriprep_reference
-        reg_with_skull: false
-      input: brain
       interpolation: trilinear
       run: true
       using: FSL
@@ -631,7 +629,7 @@ surface_analysis:
   freesurfer:
     ingress_reconall: true
     reconall_args: -clean-bm -gcut
-    run_reconall: true
+    run_reconall: false
   post_freesurfer:
     fmri_res: 2
     freesurfer_labels: /opt/dcan-tools/pipeline/global/config/FreeSurferAllLut.txt
@@ -649,11 +647,6 @@ surface_analysis:
     run: false
     surface_parcellation_template: /cpac_templates/Schaefer2018_200Parcels_17Networks_order.dlabel.nii
 timeseries_extraction:
-  connectivity_matrix:
-    measure:
-    - Pearson
-    using:
-    - AFNI
   realignment: ROI_to_func
   run: true
   tse_roi_paths:

--- a/configs/p077_base-ccs_perturb-rbc_step-functional-registration_conn-afni_nuisance-false.yml
+++ b/configs/p077_base-ccs_perturb-rbc_step-functional-registration_conn-afni_nuisance-false.yml
@@ -292,6 +292,7 @@ nuisance_corrections:
     - false
     space: native
 pipeline_setup:
+  freesurfer_dir: /ocean/projects/med220004p/trogers1/many_pipelines/freesurfer/outputs/ABCD_all_subjects
   Amazon-AWS:
     aws_output_bucket_credentials: null
     s3_encryption: false
@@ -342,7 +343,7 @@ pipeline_setup:
     random_seed: null
   working_directory:
     path: /outputs/working
-    remove_working_dir: true
+    remove_working_dir: false
 post_processing:
   spatial_smoothing:
     fwhm:
@@ -436,7 +437,6 @@ registration_workflows:
         identity_matrix: $FSLDIR/etc/flirtsch/ident.mat
         interpolation: trilinear
         ref_mask: $FSLDIR/data/standard/MNI152_T1_${resolution_for_anat}_brain_mask_dil.nii.gz
-        ref_mask_res-2: $FSLDIR/data/standard/MNI152_T1_2mm_brain_mask_dil.nii.gz
         ref_resolution: 2mm
       using:
       - FSL
@@ -527,8 +527,6 @@ registration_workflows:
           func_reg_input_volume: 0
         input:
         - fmriprep_reference
-        reg_with_skull: false
-      input: brain
       interpolation: trilinear
       run: true
       using: FSL
@@ -631,7 +629,7 @@ surface_analysis:
   freesurfer:
     ingress_reconall: true
     reconall_args: -clean-bm -gcut
-    run_reconall: true
+    run_reconall: false
   post_freesurfer:
     fmri_res: 2
     freesurfer_labels: /opt/dcan-tools/pipeline/global/config/FreeSurferAllLut.txt
@@ -649,11 +647,6 @@ surface_analysis:
     run: false
     surface_parcellation_template: /cpac_templates/Schaefer2018_200Parcels_17Networks_order.dlabel.nii
 timeseries_extraction:
-  connectivity_matrix:
-    measure:
-    - Pearson
-    using:
-    - AFNI
   realignment: ROI_to_func
   run: true
   tse_roi_paths:

--- a/configs/p078_base-ccs_perturb-rbc_step-functional-registration_conn-nilearn_nuisance-true.yml
+++ b/configs/p078_base-ccs_perturb-rbc_step-functional-registration_conn-nilearn_nuisance-true.yml
@@ -292,6 +292,7 @@ nuisance_corrections:
     - true
     space: native
 pipeline_setup:
+  freesurfer_dir: /ocean/projects/med220004p/trogers1/many_pipelines/freesurfer/outputs/ABCD_all_subjects
   Amazon-AWS:
     aws_output_bucket_credentials: null
     s3_encryption: false
@@ -342,7 +343,7 @@ pipeline_setup:
     random_seed: null
   working_directory:
     path: /outputs/working
-    remove_working_dir: true
+    remove_working_dir: false
 post_processing:
   spatial_smoothing:
     fwhm:
@@ -436,7 +437,6 @@ registration_workflows:
         identity_matrix: $FSLDIR/etc/flirtsch/ident.mat
         interpolation: trilinear
         ref_mask: $FSLDIR/data/standard/MNI152_T1_${resolution_for_anat}_brain_mask_dil.nii.gz
-        ref_mask_res-2: $FSLDIR/data/standard/MNI152_T1_2mm_brain_mask_dil.nii.gz
         ref_resolution: 2mm
       using:
       - FSL
@@ -527,8 +527,6 @@ registration_workflows:
           func_reg_input_volume: 0
         input:
         - fmriprep_reference
-        reg_with_skull: false
-      input: brain
       interpolation: trilinear
       run: true
       using: FSL
@@ -631,7 +629,7 @@ surface_analysis:
   freesurfer:
     ingress_reconall: true
     reconall_args: -clean-bm -gcut
-    run_reconall: true
+    run_reconall: false
   post_freesurfer:
     fmri_res: 2
     freesurfer_labels: /opt/dcan-tools/pipeline/global/config/FreeSurferAllLut.txt
@@ -649,11 +647,6 @@ surface_analysis:
     run: false
     surface_parcellation_template: /cpac_templates/Schaefer2018_200Parcels_17Networks_order.dlabel.nii
 timeseries_extraction:
-  connectivity_matrix:
-    measure:
-    - Pearson
-    using:
-    - Nilearn
   realignment: ROI_to_func
   run: true
   tse_roi_paths:

--- a/configs/p079_base-ccs_perturb-rbc_step-functional-registration_conn-nilearn_nuisance-false.yml
+++ b/configs/p079_base-ccs_perturb-rbc_step-functional-registration_conn-nilearn_nuisance-false.yml
@@ -292,6 +292,7 @@ nuisance_corrections:
     - false
     space: native
 pipeline_setup:
+  freesurfer_dir: /ocean/projects/med220004p/trogers1/many_pipelines/freesurfer/outputs/ABCD_all_subjects
   Amazon-AWS:
     aws_output_bucket_credentials: null
     s3_encryption: false
@@ -342,7 +343,7 @@ pipeline_setup:
     random_seed: null
   working_directory:
     path: /outputs/working
-    remove_working_dir: true
+    remove_working_dir: false
 post_processing:
   spatial_smoothing:
     fwhm:
@@ -436,7 +437,6 @@ registration_workflows:
         identity_matrix: $FSLDIR/etc/flirtsch/ident.mat
         interpolation: trilinear
         ref_mask: $FSLDIR/data/standard/MNI152_T1_${resolution_for_anat}_brain_mask_dil.nii.gz
-        ref_mask_res-2: $FSLDIR/data/standard/MNI152_T1_2mm_brain_mask_dil.nii.gz
         ref_resolution: 2mm
       using:
       - FSL
@@ -527,8 +527,6 @@ registration_workflows:
           func_reg_input_volume: 0
         input:
         - fmriprep_reference
-        reg_with_skull: false
-      input: brain
       interpolation: trilinear
       run: true
       using: FSL
@@ -631,7 +629,7 @@ surface_analysis:
   freesurfer:
     ingress_reconall: true
     reconall_args: -clean-bm -gcut
-    run_reconall: true
+    run_reconall: false
   post_freesurfer:
     fmri_res: 2
     freesurfer_labels: /opt/dcan-tools/pipeline/global/config/FreeSurferAllLut.txt
@@ -649,11 +647,6 @@ surface_analysis:
     run: false
     surface_parcellation_template: /cpac_templates/Schaefer2018_200Parcels_17Networks_order.dlabel.nii
 timeseries_extraction:
-  connectivity_matrix:
-    measure:
-    - Pearson
-    using:
-    - Nilearn
   realignment: ROI_to_func
   run: true
   tse_roi_paths:

--- a/configs/p080_base-ccs_perturb-fmriprep_step-structural-masking_conn-afni_nuisance-true.yml
+++ b/configs/p080_base-ccs_perturb-fmriprep_step-structural-masking_conn-afni_nuisance-true.yml
@@ -290,6 +290,7 @@ nuisance_corrections:
     - true
     space: native
 pipeline_setup:
+  freesurfer_dir: /ocean/projects/med220004p/trogers1/many_pipelines/freesurfer/outputs/ABCD_all_subjects
   Amazon-AWS:
     aws_output_bucket_credentials: null
     s3_encryption: false
@@ -340,7 +341,7 @@ pipeline_setup:
     random_seed: null
   working_directory:
     path: /outputs/working
-    remove_working_dir: true
+    remove_working_dir: false
 post_processing:
   spatial_smoothing:
     fwhm:
@@ -434,7 +435,6 @@ registration_workflows:
         identity_matrix: $FSLDIR/etc/flirtsch/ident.mat
         interpolation: trilinear
         ref_mask: $FSLDIR/data/standard/MNI152_T1_${resolution_for_anat}_brain_mask_dil.nii.gz
-        ref_mask_res-2: $FSLDIR/data/standard/MNI152_T1_2mm_brain_mask_dil.nii.gz
         ref_resolution: 2mm
       using:
       - FSL
@@ -525,8 +525,6 @@ registration_workflows:
           func_reg_input_volume: 7
         input:
         - Selected_Functional_Volume
-        reg_with_skull: false
-      input: brain
       interpolation: trilinear
       run: true
       using: FSL
@@ -629,7 +627,7 @@ surface_analysis:
   freesurfer:
     ingress_reconall: true
     reconall_args: -clean-bm -gcut
-    run_reconall: true
+    run_reconall: false
   post_freesurfer:
     fmri_res: 2
     freesurfer_labels: /opt/dcan-tools/pipeline/global/config/FreeSurferAllLut.txt
@@ -647,11 +645,6 @@ surface_analysis:
     run: false
     surface_parcellation_template: /cpac_templates/Schaefer2018_200Parcels_17Networks_order.dlabel.nii
 timeseries_extraction:
-  connectivity_matrix:
-    measure:
-    - Pearson
-    using:
-    - AFNI
   realignment: ROI_to_func
   run: true
   tse_roi_paths:

--- a/configs/p081_base-ccs_perturb-fmriprep_step-structural-masking_conn-afni_nuisance-false.yml
+++ b/configs/p081_base-ccs_perturb-fmriprep_step-structural-masking_conn-afni_nuisance-false.yml
@@ -290,6 +290,7 @@ nuisance_corrections:
     - false
     space: native
 pipeline_setup:
+  freesurfer_dir: /ocean/projects/med220004p/trogers1/many_pipelines/freesurfer/outputs/ABCD_all_subjects
   Amazon-AWS:
     aws_output_bucket_credentials: null
     s3_encryption: false
@@ -340,7 +341,7 @@ pipeline_setup:
     random_seed: null
   working_directory:
     path: /outputs/working
-    remove_working_dir: true
+    remove_working_dir: false
 post_processing:
   spatial_smoothing:
     fwhm:
@@ -434,7 +435,6 @@ registration_workflows:
         identity_matrix: $FSLDIR/etc/flirtsch/ident.mat
         interpolation: trilinear
         ref_mask: $FSLDIR/data/standard/MNI152_T1_${resolution_for_anat}_brain_mask_dil.nii.gz
-        ref_mask_res-2: $FSLDIR/data/standard/MNI152_T1_2mm_brain_mask_dil.nii.gz
         ref_resolution: 2mm
       using:
       - FSL
@@ -525,8 +525,6 @@ registration_workflows:
           func_reg_input_volume: 7
         input:
         - Selected_Functional_Volume
-        reg_with_skull: false
-      input: brain
       interpolation: trilinear
       run: true
       using: FSL
@@ -629,7 +627,7 @@ surface_analysis:
   freesurfer:
     ingress_reconall: true
     reconall_args: -clean-bm -gcut
-    run_reconall: true
+    run_reconall: false
   post_freesurfer:
     fmri_res: 2
     freesurfer_labels: /opt/dcan-tools/pipeline/global/config/FreeSurferAllLut.txt
@@ -647,11 +645,6 @@ surface_analysis:
     run: false
     surface_parcellation_template: /cpac_templates/Schaefer2018_200Parcels_17Networks_order.dlabel.nii
 timeseries_extraction:
-  connectivity_matrix:
-    measure:
-    - Pearson
-    using:
-    - AFNI
   realignment: ROI_to_func
   run: true
   tse_roi_paths:

--- a/configs/p082_base-ccs_perturb-fmriprep_step-structural-masking_conn-nilearn_nuisance-true.yml
+++ b/configs/p082_base-ccs_perturb-fmriprep_step-structural-masking_conn-nilearn_nuisance-true.yml
@@ -290,6 +290,7 @@ nuisance_corrections:
     - true
     space: native
 pipeline_setup:
+  freesurfer_dir: /ocean/projects/med220004p/trogers1/many_pipelines/freesurfer/outputs/ABCD_all_subjects
   Amazon-AWS:
     aws_output_bucket_credentials: null
     s3_encryption: false
@@ -340,7 +341,7 @@ pipeline_setup:
     random_seed: null
   working_directory:
     path: /outputs/working
-    remove_working_dir: true
+    remove_working_dir: false
 post_processing:
   spatial_smoothing:
     fwhm:
@@ -434,7 +435,6 @@ registration_workflows:
         identity_matrix: $FSLDIR/etc/flirtsch/ident.mat
         interpolation: trilinear
         ref_mask: $FSLDIR/data/standard/MNI152_T1_${resolution_for_anat}_brain_mask_dil.nii.gz
-        ref_mask_res-2: $FSLDIR/data/standard/MNI152_T1_2mm_brain_mask_dil.nii.gz
         ref_resolution: 2mm
       using:
       - FSL
@@ -525,8 +525,6 @@ registration_workflows:
           func_reg_input_volume: 7
         input:
         - Selected_Functional_Volume
-        reg_with_skull: false
-      input: brain
       interpolation: trilinear
       run: true
       using: FSL
@@ -629,7 +627,7 @@ surface_analysis:
   freesurfer:
     ingress_reconall: true
     reconall_args: -clean-bm -gcut
-    run_reconall: true
+    run_reconall: false
   post_freesurfer:
     fmri_res: 2
     freesurfer_labels: /opt/dcan-tools/pipeline/global/config/FreeSurferAllLut.txt
@@ -647,11 +645,6 @@ surface_analysis:
     run: false
     surface_parcellation_template: /cpac_templates/Schaefer2018_200Parcels_17Networks_order.dlabel.nii
 timeseries_extraction:
-  connectivity_matrix:
-    measure:
-    - Pearson
-    using:
-    - Nilearn
   realignment: ROI_to_func
   run: true
   tse_roi_paths:

--- a/configs/p083_base-ccs_perturb-fmriprep_step-structural-masking_conn-nilearn_nuisance-false.yml
+++ b/configs/p083_base-ccs_perturb-fmriprep_step-structural-masking_conn-nilearn_nuisance-false.yml
@@ -290,6 +290,7 @@ nuisance_corrections:
     - false
     space: native
 pipeline_setup:
+  freesurfer_dir: /ocean/projects/med220004p/trogers1/many_pipelines/freesurfer/outputs/ABCD_all_subjects
   Amazon-AWS:
     aws_output_bucket_credentials: null
     s3_encryption: false
@@ -340,7 +341,7 @@ pipeline_setup:
     random_seed: null
   working_directory:
     path: /outputs/working
-    remove_working_dir: true
+    remove_working_dir: false
 post_processing:
   spatial_smoothing:
     fwhm:
@@ -434,7 +435,6 @@ registration_workflows:
         identity_matrix: $FSLDIR/etc/flirtsch/ident.mat
         interpolation: trilinear
         ref_mask: $FSLDIR/data/standard/MNI152_T1_${resolution_for_anat}_brain_mask_dil.nii.gz
-        ref_mask_res-2: $FSLDIR/data/standard/MNI152_T1_2mm_brain_mask_dil.nii.gz
         ref_resolution: 2mm
       using:
       - FSL
@@ -525,8 +525,6 @@ registration_workflows:
           func_reg_input_volume: 7
         input:
         - Selected_Functional_Volume
-        reg_with_skull: false
-      input: brain
       interpolation: trilinear
       run: true
       using: FSL
@@ -629,7 +627,7 @@ surface_analysis:
   freesurfer:
     ingress_reconall: true
     reconall_args: -clean-bm -gcut
-    run_reconall: true
+    run_reconall: false
   post_freesurfer:
     fmri_res: 2
     freesurfer_labels: /opt/dcan-tools/pipeline/global/config/FreeSurferAllLut.txt
@@ -647,11 +645,6 @@ surface_analysis:
     run: false
     surface_parcellation_template: /cpac_templates/Schaefer2018_200Parcels_17Networks_order.dlabel.nii
 timeseries_extraction:
-  connectivity_matrix:
-    measure:
-    - Pearson
-    using:
-    - Nilearn
   realignment: ROI_to_func
   run: true
   tse_roi_paths:

--- a/configs/p084_base-ccs_perturb-fmriprep_step-structural-registration_conn-afni_nuisance-true.yml
+++ b/configs/p084_base-ccs_perturb-fmriprep_step-structural-registration_conn-afni_nuisance-true.yml
@@ -292,6 +292,7 @@ nuisance_corrections:
     - true
     space: native
 pipeline_setup:
+  freesurfer_dir: /ocean/projects/med220004p/trogers1/many_pipelines/freesurfer/outputs/ABCD_all_subjects
   Amazon-AWS:
     aws_output_bucket_credentials: null
     s3_encryption: false
@@ -342,7 +343,7 @@ pipeline_setup:
     random_seed: null
   working_directory:
     path: /outputs/working
-    remove_working_dir: true
+    remove_working_dir: false
 post_processing:
   spatial_smoothing:
     fwhm:
@@ -436,7 +437,6 @@ registration_workflows:
         identity_matrix: $FSLDIR/etc/flirtsch/ident.mat
         interpolation: sinc
         ref_mask: null
-        ref_mask_res-2: null
         ref_resolution: 2mm
       using:
       - ANTS
@@ -527,8 +527,6 @@ registration_workflows:
           func_reg_input_volume: 7
         input:
         - Selected_Functional_Volume
-        reg_with_skull: false
-      input: brain
       interpolation: trilinear
       run: true
       using: FSL
@@ -631,7 +629,7 @@ surface_analysis:
   freesurfer:
     ingress_reconall: true
     reconall_args: -clean-bm -gcut
-    run_reconall: true
+    run_reconall: false
   post_freesurfer:
     fmri_res: 2
     freesurfer_labels: /opt/dcan-tools/pipeline/global/config/FreeSurferAllLut.txt
@@ -649,11 +647,6 @@ surface_analysis:
     run: false
     surface_parcellation_template: /cpac_templates/Schaefer2018_200Parcels_17Networks_order.dlabel.nii
 timeseries_extraction:
-  connectivity_matrix:
-    measure:
-    - Pearson
-    using:
-    - AFNI
   realignment: ROI_to_func
   run: true
   tse_roi_paths:

--- a/configs/p085_base-ccs_perturb-fmriprep_step-structural-registration_conn-afni_nuisance-false.yml
+++ b/configs/p085_base-ccs_perturb-fmriprep_step-structural-registration_conn-afni_nuisance-false.yml
@@ -292,6 +292,7 @@ nuisance_corrections:
     - false
     space: native
 pipeline_setup:
+  freesurfer_dir: /ocean/projects/med220004p/trogers1/many_pipelines/freesurfer/outputs/ABCD_all_subjects
   Amazon-AWS:
     aws_output_bucket_credentials: null
     s3_encryption: false
@@ -342,7 +343,7 @@ pipeline_setup:
     random_seed: null
   working_directory:
     path: /outputs/working
-    remove_working_dir: true
+    remove_working_dir: false
 post_processing:
   spatial_smoothing:
     fwhm:
@@ -436,7 +437,6 @@ registration_workflows:
         identity_matrix: $FSLDIR/etc/flirtsch/ident.mat
         interpolation: sinc
         ref_mask: null
-        ref_mask_res-2: null
         ref_resolution: 2mm
       using:
       - ANTS
@@ -527,8 +527,6 @@ registration_workflows:
           func_reg_input_volume: 7
         input:
         - Selected_Functional_Volume
-        reg_with_skull: false
-      input: brain
       interpolation: trilinear
       run: true
       using: FSL
@@ -631,7 +629,7 @@ surface_analysis:
   freesurfer:
     ingress_reconall: true
     reconall_args: -clean-bm -gcut
-    run_reconall: true
+    run_reconall: false
   post_freesurfer:
     fmri_res: 2
     freesurfer_labels: /opt/dcan-tools/pipeline/global/config/FreeSurferAllLut.txt
@@ -649,11 +647,6 @@ surface_analysis:
     run: false
     surface_parcellation_template: /cpac_templates/Schaefer2018_200Parcels_17Networks_order.dlabel.nii
 timeseries_extraction:
-  connectivity_matrix:
-    measure:
-    - Pearson
-    using:
-    - AFNI
   realignment: ROI_to_func
   run: true
   tse_roi_paths:

--- a/configs/p086_base-ccs_perturb-fmriprep_step-structural-registration_conn-nilearn_nuisance-true.yml
+++ b/configs/p086_base-ccs_perturb-fmriprep_step-structural-registration_conn-nilearn_nuisance-true.yml
@@ -292,6 +292,7 @@ nuisance_corrections:
     - true
     space: native
 pipeline_setup:
+  freesurfer_dir: /ocean/projects/med220004p/trogers1/many_pipelines/freesurfer/outputs/ABCD_all_subjects
   Amazon-AWS:
     aws_output_bucket_credentials: null
     s3_encryption: false
@@ -342,7 +343,7 @@ pipeline_setup:
     random_seed: null
   working_directory:
     path: /outputs/working
-    remove_working_dir: true
+    remove_working_dir: false
 post_processing:
   spatial_smoothing:
     fwhm:
@@ -436,7 +437,6 @@ registration_workflows:
         identity_matrix: $FSLDIR/etc/flirtsch/ident.mat
         interpolation: sinc
         ref_mask: null
-        ref_mask_res-2: null
         ref_resolution: 2mm
       using:
       - ANTS
@@ -527,8 +527,6 @@ registration_workflows:
           func_reg_input_volume: 7
         input:
         - Selected_Functional_Volume
-        reg_with_skull: false
-      input: brain
       interpolation: trilinear
       run: true
       using: FSL
@@ -631,7 +629,7 @@ surface_analysis:
   freesurfer:
     ingress_reconall: true
     reconall_args: -clean-bm -gcut
-    run_reconall: true
+    run_reconall: false
   post_freesurfer:
     fmri_res: 2
     freesurfer_labels: /opt/dcan-tools/pipeline/global/config/FreeSurferAllLut.txt
@@ -649,11 +647,6 @@ surface_analysis:
     run: false
     surface_parcellation_template: /cpac_templates/Schaefer2018_200Parcels_17Networks_order.dlabel.nii
 timeseries_extraction:
-  connectivity_matrix:
-    measure:
-    - Pearson
-    using:
-    - Nilearn
   realignment: ROI_to_func
   run: true
   tse_roi_paths:

--- a/configs/p087_base-ccs_perturb-fmriprep_step-structural-registration_conn-nilearn_nuisance-false.yml
+++ b/configs/p087_base-ccs_perturb-fmriprep_step-structural-registration_conn-nilearn_nuisance-false.yml
@@ -292,6 +292,7 @@ nuisance_corrections:
     - false
     space: native
 pipeline_setup:
+  freesurfer_dir: /ocean/projects/med220004p/trogers1/many_pipelines/freesurfer/outputs/ABCD_all_subjects
   Amazon-AWS:
     aws_output_bucket_credentials: null
     s3_encryption: false
@@ -342,7 +343,7 @@ pipeline_setup:
     random_seed: null
   working_directory:
     path: /outputs/working
-    remove_working_dir: true
+    remove_working_dir: false
 post_processing:
   spatial_smoothing:
     fwhm:
@@ -436,7 +437,6 @@ registration_workflows:
         identity_matrix: $FSLDIR/etc/flirtsch/ident.mat
         interpolation: sinc
         ref_mask: null
-        ref_mask_res-2: null
         ref_resolution: 2mm
       using:
       - ANTS
@@ -527,8 +527,6 @@ registration_workflows:
           func_reg_input_volume: 7
         input:
         - Selected_Functional_Volume
-        reg_with_skull: false
-      input: brain
       interpolation: trilinear
       run: true
       using: FSL
@@ -631,7 +629,7 @@ surface_analysis:
   freesurfer:
     ingress_reconall: true
     reconall_args: -clean-bm -gcut
-    run_reconall: true
+    run_reconall: false
   post_freesurfer:
     fmri_res: 2
     freesurfer_labels: /opt/dcan-tools/pipeline/global/config/FreeSurferAllLut.txt
@@ -649,11 +647,6 @@ surface_analysis:
     run: false
     surface_parcellation_template: /cpac_templates/Schaefer2018_200Parcels_17Networks_order.dlabel.nii
 timeseries_extraction:
-  connectivity_matrix:
-    measure:
-    - Pearson
-    using:
-    - Nilearn
   realignment: ROI_to_func
   run: true
   tse_roi_paths:

--- a/configs/p088_base-ccs_perturb-fmriprep_step-functional-masking_conn-afni_nuisance-true.yml
+++ b/configs/p088_base-ccs_perturb-fmriprep_step-functional-masking_conn-afni_nuisance-true.yml
@@ -292,6 +292,7 @@ nuisance_corrections:
     - true
     space: native
 pipeline_setup:
+  freesurfer_dir: /ocean/projects/med220004p/trogers1/many_pipelines/freesurfer/outputs/ABCD_all_subjects
   Amazon-AWS:
     aws_output_bucket_credentials: null
     s3_encryption: false
@@ -342,7 +343,7 @@ pipeline_setup:
     random_seed: null
   working_directory:
     path: /outputs/working
-    remove_working_dir: true
+    remove_working_dir: false
 post_processing:
   spatial_smoothing:
     fwhm:
@@ -436,7 +437,6 @@ registration_workflows:
         identity_matrix: $FSLDIR/etc/flirtsch/ident.mat
         interpolation: trilinear
         ref_mask: $FSLDIR/data/standard/MNI152_T1_${resolution_for_anat}_brain_mask_dil.nii.gz
-        ref_mask_res-2: $FSLDIR/data/standard/MNI152_T1_2mm_brain_mask_dil.nii.gz
         ref_resolution: 2mm
       using:
       - FSL
@@ -527,8 +527,6 @@ registration_workflows:
           func_reg_input_volume: 7
         input:
         - Selected_Functional_Volume
-        reg_with_skull: false
-      input: brain
       interpolation: trilinear
       run: true
       using: FSL
@@ -631,7 +629,7 @@ surface_analysis:
   freesurfer:
     ingress_reconall: true
     reconall_args: -clean-bm -gcut
-    run_reconall: true
+    run_reconall: false
   post_freesurfer:
     fmri_res: 2
     freesurfer_labels: /opt/dcan-tools/pipeline/global/config/FreeSurferAllLut.txt
@@ -649,11 +647,6 @@ surface_analysis:
     run: false
     surface_parcellation_template: /cpac_templates/Schaefer2018_200Parcels_17Networks_order.dlabel.nii
 timeseries_extraction:
-  connectivity_matrix:
-    measure:
-    - Pearson
-    using:
-    - AFNI
   realignment: ROI_to_func
   run: true
   tse_roi_paths:

--- a/configs/p089_base-ccs_perturb-fmriprep_step-functional-masking_conn-afni_nuisance-false.yml
+++ b/configs/p089_base-ccs_perturb-fmriprep_step-functional-masking_conn-afni_nuisance-false.yml
@@ -292,6 +292,7 @@ nuisance_corrections:
     - false
     space: native
 pipeline_setup:
+  freesurfer_dir: /ocean/projects/med220004p/trogers1/many_pipelines/freesurfer/outputs/ABCD_all_subjects
   Amazon-AWS:
     aws_output_bucket_credentials: null
     s3_encryption: false
@@ -342,7 +343,7 @@ pipeline_setup:
     random_seed: null
   working_directory:
     path: /outputs/working
-    remove_working_dir: true
+    remove_working_dir: false
 post_processing:
   spatial_smoothing:
     fwhm:
@@ -436,7 +437,6 @@ registration_workflows:
         identity_matrix: $FSLDIR/etc/flirtsch/ident.mat
         interpolation: trilinear
         ref_mask: $FSLDIR/data/standard/MNI152_T1_${resolution_for_anat}_brain_mask_dil.nii.gz
-        ref_mask_res-2: $FSLDIR/data/standard/MNI152_T1_2mm_brain_mask_dil.nii.gz
         ref_resolution: 2mm
       using:
       - FSL
@@ -527,8 +527,6 @@ registration_workflows:
           func_reg_input_volume: 7
         input:
         - Selected_Functional_Volume
-        reg_with_skull: false
-      input: brain
       interpolation: trilinear
       run: true
       using: FSL
@@ -631,7 +629,7 @@ surface_analysis:
   freesurfer:
     ingress_reconall: true
     reconall_args: -clean-bm -gcut
-    run_reconall: true
+    run_reconall: false
   post_freesurfer:
     fmri_res: 2
     freesurfer_labels: /opt/dcan-tools/pipeline/global/config/FreeSurferAllLut.txt
@@ -649,11 +647,6 @@ surface_analysis:
     run: false
     surface_parcellation_template: /cpac_templates/Schaefer2018_200Parcels_17Networks_order.dlabel.nii
 timeseries_extraction:
-  connectivity_matrix:
-    measure:
-    - Pearson
-    using:
-    - AFNI
   realignment: ROI_to_func
   run: true
   tse_roi_paths:

--- a/configs/p090_base-ccs_perturb-fmriprep_step-functional-masking_conn-nilearn_nuisance-true.yml
+++ b/configs/p090_base-ccs_perturb-fmriprep_step-functional-masking_conn-nilearn_nuisance-true.yml
@@ -292,6 +292,7 @@ nuisance_corrections:
     - true
     space: native
 pipeline_setup:
+  freesurfer_dir: /ocean/projects/med220004p/trogers1/many_pipelines/freesurfer/outputs/ABCD_all_subjects
   Amazon-AWS:
     aws_output_bucket_credentials: null
     s3_encryption: false
@@ -342,7 +343,7 @@ pipeline_setup:
     random_seed: null
   working_directory:
     path: /outputs/working
-    remove_working_dir: true
+    remove_working_dir: false
 post_processing:
   spatial_smoothing:
     fwhm:
@@ -436,7 +437,6 @@ registration_workflows:
         identity_matrix: $FSLDIR/etc/flirtsch/ident.mat
         interpolation: trilinear
         ref_mask: $FSLDIR/data/standard/MNI152_T1_${resolution_for_anat}_brain_mask_dil.nii.gz
-        ref_mask_res-2: $FSLDIR/data/standard/MNI152_T1_2mm_brain_mask_dil.nii.gz
         ref_resolution: 2mm
       using:
       - FSL
@@ -527,8 +527,6 @@ registration_workflows:
           func_reg_input_volume: 7
         input:
         - Selected_Functional_Volume
-        reg_with_skull: false
-      input: brain
       interpolation: trilinear
       run: true
       using: FSL
@@ -631,7 +629,7 @@ surface_analysis:
   freesurfer:
     ingress_reconall: true
     reconall_args: -clean-bm -gcut
-    run_reconall: true
+    run_reconall: false
   post_freesurfer:
     fmri_res: 2
     freesurfer_labels: /opt/dcan-tools/pipeline/global/config/FreeSurferAllLut.txt
@@ -649,11 +647,6 @@ surface_analysis:
     run: false
     surface_parcellation_template: /cpac_templates/Schaefer2018_200Parcels_17Networks_order.dlabel.nii
 timeseries_extraction:
-  connectivity_matrix:
-    measure:
-    - Pearson
-    using:
-    - Nilearn
   realignment: ROI_to_func
   run: true
   tse_roi_paths:

--- a/configs/p091_base-ccs_perturb-fmriprep_step-functional-masking_conn-nilearn_nuisance-false.yml
+++ b/configs/p091_base-ccs_perturb-fmriprep_step-functional-masking_conn-nilearn_nuisance-false.yml
@@ -292,6 +292,7 @@ nuisance_corrections:
     - false
     space: native
 pipeline_setup:
+  freesurfer_dir: /ocean/projects/med220004p/trogers1/many_pipelines/freesurfer/outputs/ABCD_all_subjects
   Amazon-AWS:
     aws_output_bucket_credentials: null
     s3_encryption: false
@@ -342,7 +343,7 @@ pipeline_setup:
     random_seed: null
   working_directory:
     path: /outputs/working
-    remove_working_dir: true
+    remove_working_dir: false
 post_processing:
   spatial_smoothing:
     fwhm:
@@ -436,7 +437,6 @@ registration_workflows:
         identity_matrix: $FSLDIR/etc/flirtsch/ident.mat
         interpolation: trilinear
         ref_mask: $FSLDIR/data/standard/MNI152_T1_${resolution_for_anat}_brain_mask_dil.nii.gz
-        ref_mask_res-2: $FSLDIR/data/standard/MNI152_T1_2mm_brain_mask_dil.nii.gz
         ref_resolution: 2mm
       using:
       - FSL
@@ -527,8 +527,6 @@ registration_workflows:
           func_reg_input_volume: 7
         input:
         - Selected_Functional_Volume
-        reg_with_skull: false
-      input: brain
       interpolation: trilinear
       run: true
       using: FSL
@@ -631,7 +629,7 @@ surface_analysis:
   freesurfer:
     ingress_reconall: true
     reconall_args: -clean-bm -gcut
-    run_reconall: true
+    run_reconall: false
   post_freesurfer:
     fmri_res: 2
     freesurfer_labels: /opt/dcan-tools/pipeline/global/config/FreeSurferAllLut.txt
@@ -649,11 +647,6 @@ surface_analysis:
     run: false
     surface_parcellation_template: /cpac_templates/Schaefer2018_200Parcels_17Networks_order.dlabel.nii
 timeseries_extraction:
-  connectivity_matrix:
-    measure:
-    - Pearson
-    using:
-    - Nilearn
   realignment: ROI_to_func
   run: true
   tse_roi_paths:

--- a/configs/p092_base-ccs_perturb-fmriprep_step-functional-registration_conn-afni_nuisance-true.yml
+++ b/configs/p092_base-ccs_perturb-fmriprep_step-functional-registration_conn-afni_nuisance-true.yml
@@ -292,6 +292,7 @@ nuisance_corrections:
     - true
     space: native
 pipeline_setup:
+  freesurfer_dir: /ocean/projects/med220004p/trogers1/many_pipelines/freesurfer/outputs/ABCD_all_subjects
   Amazon-AWS:
     aws_output_bucket_credentials: null
     s3_encryption: false
@@ -342,7 +343,7 @@ pipeline_setup:
     random_seed: null
   working_directory:
     path: /outputs/working
-    remove_working_dir: true
+    remove_working_dir: false
 post_processing:
   spatial_smoothing:
     fwhm:
@@ -436,7 +437,6 @@ registration_workflows:
         identity_matrix: $FSLDIR/etc/flirtsch/ident.mat
         interpolation: trilinear
         ref_mask: $FSLDIR/data/standard/MNI152_T1_${resolution_for_anat}_brain_mask_dil.nii.gz
-        ref_mask_res-2: $FSLDIR/data/standard/MNI152_T1_2mm_brain_mask_dil.nii.gz
         ref_resolution: 2mm
       using:
       - FSL
@@ -527,8 +527,6 @@ registration_workflows:
           func_reg_input_volume: 0
         input:
         - fmriprep_reference
-        reg_with_skull: false
-      input: brain
       interpolation: trilinear
       run: true
       using: FSL
@@ -631,7 +629,7 @@ surface_analysis:
   freesurfer:
     ingress_reconall: true
     reconall_args: -clean-bm -gcut
-    run_reconall: true
+    run_reconall: false
   post_freesurfer:
     fmri_res: 2
     freesurfer_labels: /opt/dcan-tools/pipeline/global/config/FreeSurferAllLut.txt
@@ -649,11 +647,6 @@ surface_analysis:
     run: false
     surface_parcellation_template: /cpac_templates/Schaefer2018_200Parcels_17Networks_order.dlabel.nii
 timeseries_extraction:
-  connectivity_matrix:
-    measure:
-    - Pearson
-    using:
-    - AFNI
   realignment: ROI_to_func
   run: true
   tse_roi_paths:

--- a/configs/p093_base-ccs_perturb-fmriprep_step-functional-registration_conn-afni_nuisance-false.yml
+++ b/configs/p093_base-ccs_perturb-fmriprep_step-functional-registration_conn-afni_nuisance-false.yml
@@ -292,6 +292,7 @@ nuisance_corrections:
     - false
     space: native
 pipeline_setup:
+  freesurfer_dir: /ocean/projects/med220004p/trogers1/many_pipelines/freesurfer/outputs/ABCD_all_subjects
   Amazon-AWS:
     aws_output_bucket_credentials: null
     s3_encryption: false
@@ -342,7 +343,7 @@ pipeline_setup:
     random_seed: null
   working_directory:
     path: /outputs/working
-    remove_working_dir: true
+    remove_working_dir: false
 post_processing:
   spatial_smoothing:
     fwhm:
@@ -436,7 +437,6 @@ registration_workflows:
         identity_matrix: $FSLDIR/etc/flirtsch/ident.mat
         interpolation: trilinear
         ref_mask: $FSLDIR/data/standard/MNI152_T1_${resolution_for_anat}_brain_mask_dil.nii.gz
-        ref_mask_res-2: $FSLDIR/data/standard/MNI152_T1_2mm_brain_mask_dil.nii.gz
         ref_resolution: 2mm
       using:
       - FSL
@@ -527,8 +527,6 @@ registration_workflows:
           func_reg_input_volume: 0
         input:
         - fmriprep_reference
-        reg_with_skull: false
-      input: brain
       interpolation: trilinear
       run: true
       using: FSL
@@ -631,7 +629,7 @@ surface_analysis:
   freesurfer:
     ingress_reconall: true
     reconall_args: -clean-bm -gcut
-    run_reconall: true
+    run_reconall: false
   post_freesurfer:
     fmri_res: 2
     freesurfer_labels: /opt/dcan-tools/pipeline/global/config/FreeSurferAllLut.txt
@@ -649,11 +647,6 @@ surface_analysis:
     run: false
     surface_parcellation_template: /cpac_templates/Schaefer2018_200Parcels_17Networks_order.dlabel.nii
 timeseries_extraction:
-  connectivity_matrix:
-    measure:
-    - Pearson
-    using:
-    - AFNI
   realignment: ROI_to_func
   run: true
   tse_roi_paths:

--- a/configs/p094_base-ccs_perturb-fmriprep_step-functional-registration_conn-nilearn_nuisance-true.yml
+++ b/configs/p094_base-ccs_perturb-fmriprep_step-functional-registration_conn-nilearn_nuisance-true.yml
@@ -292,6 +292,7 @@ nuisance_corrections:
     - true
     space: native
 pipeline_setup:
+  freesurfer_dir: /ocean/projects/med220004p/trogers1/many_pipelines/freesurfer/outputs/ABCD_all_subjects
   Amazon-AWS:
     aws_output_bucket_credentials: null
     s3_encryption: false
@@ -342,7 +343,7 @@ pipeline_setup:
     random_seed: null
   working_directory:
     path: /outputs/working
-    remove_working_dir: true
+    remove_working_dir: false
 post_processing:
   spatial_smoothing:
     fwhm:
@@ -436,7 +437,6 @@ registration_workflows:
         identity_matrix: $FSLDIR/etc/flirtsch/ident.mat
         interpolation: trilinear
         ref_mask: $FSLDIR/data/standard/MNI152_T1_${resolution_for_anat}_brain_mask_dil.nii.gz
-        ref_mask_res-2: $FSLDIR/data/standard/MNI152_T1_2mm_brain_mask_dil.nii.gz
         ref_resolution: 2mm
       using:
       - FSL
@@ -527,8 +527,6 @@ registration_workflows:
           func_reg_input_volume: 0
         input:
         - fmriprep_reference
-        reg_with_skull: false
-      input: brain
       interpolation: trilinear
       run: true
       using: FSL
@@ -631,7 +629,7 @@ surface_analysis:
   freesurfer:
     ingress_reconall: true
     reconall_args: -clean-bm -gcut
-    run_reconall: true
+    run_reconall: false
   post_freesurfer:
     fmri_res: 2
     freesurfer_labels: /opt/dcan-tools/pipeline/global/config/FreeSurferAllLut.txt
@@ -649,11 +647,6 @@ surface_analysis:
     run: false
     surface_parcellation_template: /cpac_templates/Schaefer2018_200Parcels_17Networks_order.dlabel.nii
 timeseries_extraction:
-  connectivity_matrix:
-    measure:
-    - Pearson
-    using:
-    - Nilearn
   realignment: ROI_to_func
   run: true
   tse_roi_paths:

--- a/configs/p095_base-ccs_perturb-fmriprep_step-functional-registration_conn-nilearn_nuisance-false.yml
+++ b/configs/p095_base-ccs_perturb-fmriprep_step-functional-registration_conn-nilearn_nuisance-false.yml
@@ -292,6 +292,7 @@ nuisance_corrections:
     - false
     space: native
 pipeline_setup:
+  freesurfer_dir: /ocean/projects/med220004p/trogers1/many_pipelines/freesurfer/outputs/ABCD_all_subjects
   Amazon-AWS:
     aws_output_bucket_credentials: null
     s3_encryption: false
@@ -342,7 +343,7 @@ pipeline_setup:
     random_seed: null
   working_directory:
     path: /outputs/working
-    remove_working_dir: true
+    remove_working_dir: false
 post_processing:
   spatial_smoothing:
     fwhm:
@@ -436,7 +437,6 @@ registration_workflows:
         identity_matrix: $FSLDIR/etc/flirtsch/ident.mat
         interpolation: trilinear
         ref_mask: $FSLDIR/data/standard/MNI152_T1_${resolution_for_anat}_brain_mask_dil.nii.gz
-        ref_mask_res-2: $FSLDIR/data/standard/MNI152_T1_2mm_brain_mask_dil.nii.gz
         ref_resolution: 2mm
       using:
       - FSL
@@ -527,8 +527,6 @@ registration_workflows:
           func_reg_input_volume: 0
         input:
         - fmriprep_reference
-        reg_with_skull: false
-      input: brain
       interpolation: trilinear
       run: true
       using: FSL
@@ -631,7 +629,7 @@ surface_analysis:
   freesurfer:
     ingress_reconall: true
     reconall_args: -clean-bm -gcut
-    run_reconall: true
+    run_reconall: false
   post_freesurfer:
     fmri_res: 2
     freesurfer_labels: /opt/dcan-tools/pipeline/global/config/FreeSurferAllLut.txt
@@ -649,11 +647,6 @@ surface_analysis:
     run: false
     surface_parcellation_template: /cpac_templates/Schaefer2018_200Parcels_17Networks_order.dlabel.nii
 timeseries_extraction:
-  connectivity_matrix:
-    measure:
-    - Pearson
-    using:
-    - Nilearn
   realignment: ROI_to_func
   run: true
   tse_roi_paths:

--- a/configs/p096_base-rbc_perturb-abcd_step-structural-masking_conn-afni_nuisance-true.yml
+++ b/configs/p096_base-rbc_perturb-abcd_step-structural-masking_conn-afni_nuisance-true.yml
@@ -310,6 +310,7 @@ nuisance_corrections:
     - true
     space: template
 pipeline_setup:
+  freesurfer_dir: /ocean/projects/med220004p/trogers1/many_pipelines/freesurfer/outputs/ABCD_all_subjects
   Amazon-AWS:
     aws_output_bucket_credentials: null
     s3_encryption: true
@@ -360,7 +361,7 @@ pipeline_setup:
     random_seed: 77742777
   working_directory:
     path: /outputs/working
-    remove_working_dir: true
+    remove_working_dir: false
 post_processing:
   spatial_smoothing:
     fwhm:
@@ -387,7 +388,7 @@ registration_workflows:
     T1w_brain_template_mask: $FSLDIR/data/standard/MNI152_T1_${resolution_for_anat}_brain_mask.nii.gz
     T1w_template: $FSLDIR/data/standard/MNI152_T1_${resolution_for_anat}.nii.gz
     overwrite_transform:
-      run: false
+      run: true
       using: FSL
     reg_with_skull: false
     registration:
@@ -451,12 +452,11 @@ registration_workflows:
       FSL-FNIRT:
         FNIRT_T1w_brain_template: null
         FNIRT_T1w_template: null
-        T1w_template_res-2: null
+        T1w_template_res-2: $FSLDIR/data/standard/MNI152_T1_2mm_brain.nii.gz
         fnirt_config: T1_2_MNI152_2mm
         identity_matrix: $FSLDIR/etc/flirtsch/ident.mat
         interpolation: sinc
         ref_mask: null
-        ref_mask_res-2: null
         ref_resolution: 2mm
       using:
       - ANTS
@@ -494,8 +494,6 @@ registration_workflows:
           func_reg_input_volume: 0
         input:
         - fmriprep_reference
-        reg_with_skull: false
-      input: brain
       interpolation: trilinear
       run: true
       using: FSL
@@ -572,7 +570,7 @@ segmentation:
     - FSL-FAST
 surface_analysis:
   abcd_prefreesurfer_prep:
-    run: false
+    run: true
   amplitude_low_frequency_fluctuation:
     run: false
   freesurfer:
@@ -596,11 +594,6 @@ surface_analysis:
     run: false
     surface_parcellation_template: /cpac_templates/Schaefer2018_200Parcels_17Networks_order.dlabel.nii
 timeseries_extraction:
-  connectivity_matrix:
-    measure:
-    - Pearson
-    using:
-    - AFNI
   realignment: ROI_to_func
   run: true
   tse_roi_paths:

--- a/configs/p097_base-rbc_perturb-abcd_step-structural-masking_conn-afni_nuisance-false.yml
+++ b/configs/p097_base-rbc_perturb-abcd_step-structural-masking_conn-afni_nuisance-false.yml
@@ -310,6 +310,7 @@ nuisance_corrections:
     - false
     space: template
 pipeline_setup:
+  freesurfer_dir: /ocean/projects/med220004p/trogers1/many_pipelines/freesurfer/outputs/ABCD_all_subjects
   Amazon-AWS:
     aws_output_bucket_credentials: null
     s3_encryption: true
@@ -360,7 +361,7 @@ pipeline_setup:
     random_seed: 77742777
   working_directory:
     path: /outputs/working
-    remove_working_dir: true
+    remove_working_dir: false
 post_processing:
   spatial_smoothing:
     fwhm:
@@ -387,7 +388,7 @@ registration_workflows:
     T1w_brain_template_mask: $FSLDIR/data/standard/MNI152_T1_${resolution_for_anat}_brain_mask.nii.gz
     T1w_template: $FSLDIR/data/standard/MNI152_T1_${resolution_for_anat}.nii.gz
     overwrite_transform:
-      run: false
+      run: true
       using: FSL
     reg_with_skull: false
     registration:
@@ -451,12 +452,11 @@ registration_workflows:
       FSL-FNIRT:
         FNIRT_T1w_brain_template: null
         FNIRT_T1w_template: null
-        T1w_template_res-2: null
+        T1w_template_res-2: $FSLDIR/data/standard/MNI152_T1_2mm_brain.nii.gz
         fnirt_config: T1_2_MNI152_2mm
         identity_matrix: $FSLDIR/etc/flirtsch/ident.mat
         interpolation: sinc
         ref_mask: null
-        ref_mask_res-2: null
         ref_resolution: 2mm
       using:
       - ANTS
@@ -494,8 +494,6 @@ registration_workflows:
           func_reg_input_volume: 0
         input:
         - fmriprep_reference
-        reg_with_skull: false
-      input: brain
       interpolation: trilinear
       run: true
       using: FSL
@@ -572,7 +570,7 @@ segmentation:
     - FSL-FAST
 surface_analysis:
   abcd_prefreesurfer_prep:
-    run: false
+    run: true
   amplitude_low_frequency_fluctuation:
     run: false
   freesurfer:
@@ -596,11 +594,6 @@ surface_analysis:
     run: false
     surface_parcellation_template: /cpac_templates/Schaefer2018_200Parcels_17Networks_order.dlabel.nii
 timeseries_extraction:
-  connectivity_matrix:
-    measure:
-    - Pearson
-    using:
-    - AFNI
   realignment: ROI_to_func
   run: true
   tse_roi_paths:

--- a/configs/p098_base-rbc_perturb-abcd_step-structural-masking_conn-nilearn_nuisance-true.yml
+++ b/configs/p098_base-rbc_perturb-abcd_step-structural-masking_conn-nilearn_nuisance-true.yml
@@ -310,6 +310,7 @@ nuisance_corrections:
     - true
     space: template
 pipeline_setup:
+  freesurfer_dir: /ocean/projects/med220004p/trogers1/many_pipelines/freesurfer/outputs/ABCD_all_subjects
   Amazon-AWS:
     aws_output_bucket_credentials: null
     s3_encryption: true
@@ -360,7 +361,7 @@ pipeline_setup:
     random_seed: 77742777
   working_directory:
     path: /outputs/working
-    remove_working_dir: true
+    remove_working_dir: false
 post_processing:
   spatial_smoothing:
     fwhm:
@@ -387,7 +388,7 @@ registration_workflows:
     T1w_brain_template_mask: $FSLDIR/data/standard/MNI152_T1_${resolution_for_anat}_brain_mask.nii.gz
     T1w_template: $FSLDIR/data/standard/MNI152_T1_${resolution_for_anat}.nii.gz
     overwrite_transform:
-      run: false
+      run: true
       using: FSL
     reg_with_skull: false
     registration:
@@ -451,12 +452,11 @@ registration_workflows:
       FSL-FNIRT:
         FNIRT_T1w_brain_template: null
         FNIRT_T1w_template: null
-        T1w_template_res-2: null
+        T1w_template_res-2: $FSLDIR/data/standard/MNI152_T1_2mm_brain.nii.gz
         fnirt_config: T1_2_MNI152_2mm
         identity_matrix: $FSLDIR/etc/flirtsch/ident.mat
         interpolation: sinc
         ref_mask: null
-        ref_mask_res-2: null
         ref_resolution: 2mm
       using:
       - ANTS
@@ -494,8 +494,6 @@ registration_workflows:
           func_reg_input_volume: 0
         input:
         - fmriprep_reference
-        reg_with_skull: false
-      input: brain
       interpolation: trilinear
       run: true
       using: FSL
@@ -572,7 +570,7 @@ segmentation:
     - FSL-FAST
 surface_analysis:
   abcd_prefreesurfer_prep:
-    run: false
+    run: true
   amplitude_low_frequency_fluctuation:
     run: false
   freesurfer:
@@ -596,11 +594,6 @@ surface_analysis:
     run: false
     surface_parcellation_template: /cpac_templates/Schaefer2018_200Parcels_17Networks_order.dlabel.nii
 timeseries_extraction:
-  connectivity_matrix:
-    measure:
-    - Pearson
-    using:
-    - Nilearn
   realignment: ROI_to_func
   run: true
   tse_roi_paths:

--- a/configs/p099_base-rbc_perturb-abcd_step-structural-masking_conn-nilearn_nuisance-false.yml
+++ b/configs/p099_base-rbc_perturb-abcd_step-structural-masking_conn-nilearn_nuisance-false.yml
@@ -310,6 +310,7 @@ nuisance_corrections:
     - false
     space: template
 pipeline_setup:
+  freesurfer_dir: /ocean/projects/med220004p/trogers1/many_pipelines/freesurfer/outputs/ABCD_all_subjects
   Amazon-AWS:
     aws_output_bucket_credentials: null
     s3_encryption: true
@@ -360,7 +361,7 @@ pipeline_setup:
     random_seed: 77742777
   working_directory:
     path: /outputs/working
-    remove_working_dir: true
+    remove_working_dir: false
 post_processing:
   spatial_smoothing:
     fwhm:
@@ -387,7 +388,7 @@ registration_workflows:
     T1w_brain_template_mask: $FSLDIR/data/standard/MNI152_T1_${resolution_for_anat}_brain_mask.nii.gz
     T1w_template: $FSLDIR/data/standard/MNI152_T1_${resolution_for_anat}.nii.gz
     overwrite_transform:
-      run: false
+      run: true
       using: FSL
     reg_with_skull: false
     registration:
@@ -451,12 +452,11 @@ registration_workflows:
       FSL-FNIRT:
         FNIRT_T1w_brain_template: null
         FNIRT_T1w_template: null
-        T1w_template_res-2: null
+        T1w_template_res-2: $FSLDIR/data/standard/MNI152_T1_2mm_brain.nii.gz
         fnirt_config: T1_2_MNI152_2mm
         identity_matrix: $FSLDIR/etc/flirtsch/ident.mat
         interpolation: sinc
         ref_mask: null
-        ref_mask_res-2: null
         ref_resolution: 2mm
       using:
       - ANTS
@@ -494,8 +494,6 @@ registration_workflows:
           func_reg_input_volume: 0
         input:
         - fmriprep_reference
-        reg_with_skull: false
-      input: brain
       interpolation: trilinear
       run: true
       using: FSL
@@ -572,7 +570,7 @@ segmentation:
     - FSL-FAST
 surface_analysis:
   abcd_prefreesurfer_prep:
-    run: false
+    run: true
   amplitude_low_frequency_fluctuation:
     run: false
   freesurfer:
@@ -596,11 +594,6 @@ surface_analysis:
     run: false
     surface_parcellation_template: /cpac_templates/Schaefer2018_200Parcels_17Networks_order.dlabel.nii
 timeseries_extraction:
-  connectivity_matrix:
-    measure:
-    - Pearson
-    using:
-    - Nilearn
   realignment: ROI_to_func
   run: true
   tse_roi_paths:

--- a/configs/p100_base-rbc_perturb-abcd_step-structural-registration_conn-afni_nuisance-true.yml
+++ b/configs/p100_base-rbc_perturb-abcd_step-structural-registration_conn-afni_nuisance-true.yml
@@ -310,6 +310,7 @@ nuisance_corrections:
     - true
     space: template
 pipeline_setup:
+  freesurfer_dir: /ocean/projects/med220004p/trogers1/many_pipelines/freesurfer/outputs/ABCD_all_subjects
   Amazon-AWS:
     aws_output_bucket_credentials: null
     s3_encryption: true
@@ -360,7 +361,7 @@ pipeline_setup:
     random_seed: 77742777
   working_directory:
     path: /outputs/working
-    remove_working_dir: true
+    remove_working_dir: false
 post_processing:
   spatial_smoothing:
     fwhm:
@@ -456,12 +457,10 @@ registration_workflows:
       FSL-FNIRT:
         FNIRT_T1w_brain_template: null
         FNIRT_T1w_template: null
-        T1w_template_res-2: /opt/dcan-tools/pipeline/global/templates/MNI152_T1_2mm.nii.gz
         fnirt_config: T1_2_MNI152_2mm
         identity_matrix: $FSLDIR/etc/flirtsch/ident.mat
         interpolation: sinc
         ref_mask: $FSLDIR/data/standard/MNI152_T1_${resolution_for_anat}_brain_mask_dil.nii.gz
-        ref_mask_res-2: /opt/dcan-tools/pipeline/global/templates/MNI152_T1_2mm_brain_mask_dil.nii.gz
         ref_resolution: 2mm
       using:
       - ANTS
@@ -499,8 +498,6 @@ registration_workflows:
           func_reg_input_volume: 0
         input:
         - fmriprep_reference
-        reg_with_skull: false
-      input: brain
       interpolation: trilinear
       run: true
       using: FSL
@@ -601,11 +598,6 @@ surface_analysis:
     run: false
     surface_parcellation_template: /cpac_templates/Schaefer2018_200Parcels_17Networks_order.dlabel.nii
 timeseries_extraction:
-  connectivity_matrix:
-    measure:
-    - Pearson
-    using:
-    - AFNI
   realignment: ROI_to_func
   run: true
   tse_roi_paths:

--- a/configs/p101_base-rbc_perturb-abcd_step-structural-registration_conn-afni_nuisance-false.yml
+++ b/configs/p101_base-rbc_perturb-abcd_step-structural-registration_conn-afni_nuisance-false.yml
@@ -310,6 +310,7 @@ nuisance_corrections:
     - false
     space: template
 pipeline_setup:
+  freesurfer_dir: /ocean/projects/med220004p/trogers1/many_pipelines/freesurfer/outputs/ABCD_all_subjects
   Amazon-AWS:
     aws_output_bucket_credentials: null
     s3_encryption: true
@@ -360,7 +361,7 @@ pipeline_setup:
     random_seed: 77742777
   working_directory:
     path: /outputs/working
-    remove_working_dir: true
+    remove_working_dir: false
 post_processing:
   spatial_smoothing:
     fwhm:
@@ -456,12 +457,10 @@ registration_workflows:
       FSL-FNIRT:
         FNIRT_T1w_brain_template: null
         FNIRT_T1w_template: null
-        T1w_template_res-2: /opt/dcan-tools/pipeline/global/templates/MNI152_T1_2mm.nii.gz
         fnirt_config: T1_2_MNI152_2mm
         identity_matrix: $FSLDIR/etc/flirtsch/ident.mat
         interpolation: sinc
         ref_mask: $FSLDIR/data/standard/MNI152_T1_${resolution_for_anat}_brain_mask_dil.nii.gz
-        ref_mask_res-2: /opt/dcan-tools/pipeline/global/templates/MNI152_T1_2mm_brain_mask_dil.nii.gz
         ref_resolution: 2mm
       using:
       - ANTS
@@ -499,8 +498,6 @@ registration_workflows:
           func_reg_input_volume: 0
         input:
         - fmriprep_reference
-        reg_with_skull: false
-      input: brain
       interpolation: trilinear
       run: true
       using: FSL
@@ -601,11 +598,6 @@ surface_analysis:
     run: false
     surface_parcellation_template: /cpac_templates/Schaefer2018_200Parcels_17Networks_order.dlabel.nii
 timeseries_extraction:
-  connectivity_matrix:
-    measure:
-    - Pearson
-    using:
-    - AFNI
   realignment: ROI_to_func
   run: true
   tse_roi_paths:

--- a/configs/p102_base-rbc_perturb-abcd_step-structural-registration_conn-nilearn_nuisance-true.yml
+++ b/configs/p102_base-rbc_perturb-abcd_step-structural-registration_conn-nilearn_nuisance-true.yml
@@ -310,6 +310,7 @@ nuisance_corrections:
     - true
     space: template
 pipeline_setup:
+  freesurfer_dir: /ocean/projects/med220004p/trogers1/many_pipelines/freesurfer/outputs/ABCD_all_subjects
   Amazon-AWS:
     aws_output_bucket_credentials: null
     s3_encryption: true
@@ -360,7 +361,7 @@ pipeline_setup:
     random_seed: 77742777
   working_directory:
     path: /outputs/working
-    remove_working_dir: true
+    remove_working_dir: false
 post_processing:
   spatial_smoothing:
     fwhm:
@@ -456,12 +457,10 @@ registration_workflows:
       FSL-FNIRT:
         FNIRT_T1w_brain_template: null
         FNIRT_T1w_template: null
-        T1w_template_res-2: /opt/dcan-tools/pipeline/global/templates/MNI152_T1_2mm.nii.gz
         fnirt_config: T1_2_MNI152_2mm
         identity_matrix: $FSLDIR/etc/flirtsch/ident.mat
         interpolation: sinc
         ref_mask: $FSLDIR/data/standard/MNI152_T1_${resolution_for_anat}_brain_mask_dil.nii.gz
-        ref_mask_res-2: /opt/dcan-tools/pipeline/global/templates/MNI152_T1_2mm_brain_mask_dil.nii.gz
         ref_resolution: 2mm
       using:
       - ANTS
@@ -499,8 +498,6 @@ registration_workflows:
           func_reg_input_volume: 0
         input:
         - fmriprep_reference
-        reg_with_skull: false
-      input: brain
       interpolation: trilinear
       run: true
       using: FSL
@@ -601,11 +598,6 @@ surface_analysis:
     run: false
     surface_parcellation_template: /cpac_templates/Schaefer2018_200Parcels_17Networks_order.dlabel.nii
 timeseries_extraction:
-  connectivity_matrix:
-    measure:
-    - Pearson
-    using:
-    - Nilearn
   realignment: ROI_to_func
   run: true
   tse_roi_paths:

--- a/configs/p103_base-rbc_perturb-abcd_step-structural-registration_conn-nilearn_nuisance-false.yml
+++ b/configs/p103_base-rbc_perturb-abcd_step-structural-registration_conn-nilearn_nuisance-false.yml
@@ -310,6 +310,7 @@ nuisance_corrections:
     - false
     space: template
 pipeline_setup:
+  freesurfer_dir: /ocean/projects/med220004p/trogers1/many_pipelines/freesurfer/outputs/ABCD_all_subjects
   Amazon-AWS:
     aws_output_bucket_credentials: null
     s3_encryption: true
@@ -360,7 +361,7 @@ pipeline_setup:
     random_seed: 77742777
   working_directory:
     path: /outputs/working
-    remove_working_dir: true
+    remove_working_dir: false
 post_processing:
   spatial_smoothing:
     fwhm:
@@ -456,12 +457,10 @@ registration_workflows:
       FSL-FNIRT:
         FNIRT_T1w_brain_template: null
         FNIRT_T1w_template: null
-        T1w_template_res-2: /opt/dcan-tools/pipeline/global/templates/MNI152_T1_2mm.nii.gz
         fnirt_config: T1_2_MNI152_2mm
         identity_matrix: $FSLDIR/etc/flirtsch/ident.mat
         interpolation: sinc
         ref_mask: $FSLDIR/data/standard/MNI152_T1_${resolution_for_anat}_brain_mask_dil.nii.gz
-        ref_mask_res-2: /opt/dcan-tools/pipeline/global/templates/MNI152_T1_2mm_brain_mask_dil.nii.gz
         ref_resolution: 2mm
       using:
       - ANTS
@@ -499,8 +498,6 @@ registration_workflows:
           func_reg_input_volume: 0
         input:
         - fmriprep_reference
-        reg_with_skull: false
-      input: brain
       interpolation: trilinear
       run: true
       using: FSL
@@ -601,11 +598,6 @@ surface_analysis:
     run: false
     surface_parcellation_template: /cpac_templates/Schaefer2018_200Parcels_17Networks_order.dlabel.nii
 timeseries_extraction:
-  connectivity_matrix:
-    measure:
-    - Pearson
-    using:
-    - Nilearn
   realignment: ROI_to_func
   run: true
   tse_roi_paths:

--- a/configs/p104_base-rbc_perturb-abcd_step-functional-masking_conn-afni_nuisance-true.yml
+++ b/configs/p104_base-rbc_perturb-abcd_step-functional-masking_conn-afni_nuisance-true.yml
@@ -149,7 +149,7 @@ functional_preproc:
     apply_func_mask_in_native_space: false
     run: true
     using:
-    - Anatomical_Resampled
+    - CCS_Anatomical_Refined
   generate_func_mean:
     run: true
   motion_estimates_and_correction:
@@ -310,6 +310,7 @@ nuisance_corrections:
     - true
     space: template
 pipeline_setup:
+  freesurfer_dir: /ocean/projects/med220004p/trogers1/many_pipelines/freesurfer/outputs/ABCD_all_subjects
   Amazon-AWS:
     aws_output_bucket_credentials: null
     s3_encryption: true
@@ -360,7 +361,7 @@ pipeline_setup:
     random_seed: 77742777
   working_directory:
     path: /outputs/working
-    remove_working_dir: true
+    remove_working_dir: false
 post_processing:
   spatial_smoothing:
     fwhm:
@@ -387,7 +388,7 @@ registration_workflows:
     T1w_brain_template_mask: /opt/dcan-tools/pipeline/global/templates/MNI152_T1_${resolution_for_anat}_brain_mask.nii.gz
     T1w_template: $FSLDIR/data/standard/MNI152_T1_${resolution_for_anat}.nii.gz
     overwrite_transform:
-      run: false
+      run: true
       using: FSL
     reg_with_skull: false
     registration:
@@ -456,7 +457,6 @@ registration_workflows:
         identity_matrix: $FSLDIR/etc/flirtsch/ident.mat
         interpolation: sinc
         ref_mask: null
-        ref_mask_res-2: null
         ref_resolution: 2mm
       using:
       - ANTS
@@ -494,8 +494,6 @@ registration_workflows:
           func_reg_input_volume: 0
         input:
         - fmriprep_reference
-        reg_with_skull: false
-      input: brain
       interpolation: trilinear
       run: true
       using: FSL
@@ -596,11 +594,6 @@ surface_analysis:
     run: false
     surface_parcellation_template: /cpac_templates/Schaefer2018_200Parcels_17Networks_order.dlabel.nii
 timeseries_extraction:
-  connectivity_matrix:
-    measure:
-    - Pearson
-    using:
-    - AFNI
   realignment: ROI_to_func
   run: true
   tse_roi_paths:

--- a/configs/p105_base-rbc_perturb-abcd_step-functional-masking_conn-afni_nuisance-false.yml
+++ b/configs/p105_base-rbc_perturb-abcd_step-functional-masking_conn-afni_nuisance-false.yml
@@ -149,7 +149,7 @@ functional_preproc:
     apply_func_mask_in_native_space: false
     run: true
     using:
-    - Anatomical_Resampled
+    - CCS_Anatomical_Refined
   generate_func_mean:
     run: true
   motion_estimates_and_correction:
@@ -310,6 +310,7 @@ nuisance_corrections:
     - false
     space: template
 pipeline_setup:
+  freesurfer_dir: /ocean/projects/med220004p/trogers1/many_pipelines/freesurfer/outputs/ABCD_all_subjects
   Amazon-AWS:
     aws_output_bucket_credentials: null
     s3_encryption: true
@@ -360,7 +361,7 @@ pipeline_setup:
     random_seed: 77742777
   working_directory:
     path: /outputs/working
-    remove_working_dir: true
+    remove_working_dir: false
 post_processing:
   spatial_smoothing:
     fwhm:
@@ -387,7 +388,7 @@ registration_workflows:
     T1w_brain_template_mask: /opt/dcan-tools/pipeline/global/templates/MNI152_T1_${resolution_for_anat}_brain_mask.nii.gz
     T1w_template: $FSLDIR/data/standard/MNI152_T1_${resolution_for_anat}.nii.gz
     overwrite_transform:
-      run: false
+      run: true
       using: FSL
     reg_with_skull: false
     registration:
@@ -456,7 +457,6 @@ registration_workflows:
         identity_matrix: $FSLDIR/etc/flirtsch/ident.mat
         interpolation: sinc
         ref_mask: null
-        ref_mask_res-2: null
         ref_resolution: 2mm
       using:
       - ANTS
@@ -494,8 +494,6 @@ registration_workflows:
           func_reg_input_volume: 0
         input:
         - fmriprep_reference
-        reg_with_skull: false
-      input: brain
       interpolation: trilinear
       run: true
       using: FSL
@@ -596,11 +594,6 @@ surface_analysis:
     run: false
     surface_parcellation_template: /cpac_templates/Schaefer2018_200Parcels_17Networks_order.dlabel.nii
 timeseries_extraction:
-  connectivity_matrix:
-    measure:
-    - Pearson
-    using:
-    - AFNI
   realignment: ROI_to_func
   run: true
   tse_roi_paths:

--- a/configs/p106_base-rbc_perturb-abcd_step-functional-masking_conn-nilearn_nuisance-true.yml
+++ b/configs/p106_base-rbc_perturb-abcd_step-functional-masking_conn-nilearn_nuisance-true.yml
@@ -149,7 +149,7 @@ functional_preproc:
     apply_func_mask_in_native_space: false
     run: true
     using:
-    - Anatomical_Resampled
+    - CCS_Anatomical_Refined
   generate_func_mean:
     run: true
   motion_estimates_and_correction:
@@ -310,6 +310,7 @@ nuisance_corrections:
     - true
     space: template
 pipeline_setup:
+  freesurfer_dir: /ocean/projects/med220004p/trogers1/many_pipelines/freesurfer/outputs/ABCD_all_subjects
   Amazon-AWS:
     aws_output_bucket_credentials: null
     s3_encryption: true
@@ -360,7 +361,7 @@ pipeline_setup:
     random_seed: 77742777
   working_directory:
     path: /outputs/working
-    remove_working_dir: true
+    remove_working_dir: false
 post_processing:
   spatial_smoothing:
     fwhm:
@@ -387,7 +388,7 @@ registration_workflows:
     T1w_brain_template_mask: /opt/dcan-tools/pipeline/global/templates/MNI152_T1_${resolution_for_anat}_brain_mask.nii.gz
     T1w_template: $FSLDIR/data/standard/MNI152_T1_${resolution_for_anat}.nii.gz
     overwrite_transform:
-      run: false
+      run: true
       using: FSL
     reg_with_skull: false
     registration:
@@ -456,7 +457,6 @@ registration_workflows:
         identity_matrix: $FSLDIR/etc/flirtsch/ident.mat
         interpolation: sinc
         ref_mask: null
-        ref_mask_res-2: null
         ref_resolution: 2mm
       using:
       - ANTS
@@ -494,8 +494,6 @@ registration_workflows:
           func_reg_input_volume: 0
         input:
         - fmriprep_reference
-        reg_with_skull: false
-      input: brain
       interpolation: trilinear
       run: true
       using: FSL
@@ -596,11 +594,6 @@ surface_analysis:
     run: false
     surface_parcellation_template: /cpac_templates/Schaefer2018_200Parcels_17Networks_order.dlabel.nii
 timeseries_extraction:
-  connectivity_matrix:
-    measure:
-    - Pearson
-    using:
-    - Nilearn
   realignment: ROI_to_func
   run: true
   tse_roi_paths:

--- a/configs/p107_base-rbc_perturb-abcd_step-functional-masking_conn-nilearn_nuisance-false.yml
+++ b/configs/p107_base-rbc_perturb-abcd_step-functional-masking_conn-nilearn_nuisance-false.yml
@@ -149,7 +149,7 @@ functional_preproc:
     apply_func_mask_in_native_space: false
     run: true
     using:
-    - Anatomical_Resampled
+    - CCS_Anatomical_Refined
   generate_func_mean:
     run: true
   motion_estimates_and_correction:
@@ -310,6 +310,7 @@ nuisance_corrections:
     - false
     space: template
 pipeline_setup:
+  freesurfer_dir: /ocean/projects/med220004p/trogers1/many_pipelines/freesurfer/outputs/ABCD_all_subjects
   Amazon-AWS:
     aws_output_bucket_credentials: null
     s3_encryption: true
@@ -360,7 +361,7 @@ pipeline_setup:
     random_seed: 77742777
   working_directory:
     path: /outputs/working
-    remove_working_dir: true
+    remove_working_dir: false
 post_processing:
   spatial_smoothing:
     fwhm:
@@ -387,7 +388,7 @@ registration_workflows:
     T1w_brain_template_mask: /opt/dcan-tools/pipeline/global/templates/MNI152_T1_${resolution_for_anat}_brain_mask.nii.gz
     T1w_template: $FSLDIR/data/standard/MNI152_T1_${resolution_for_anat}.nii.gz
     overwrite_transform:
-      run: false
+      run: true
       using: FSL
     reg_with_skull: false
     registration:
@@ -456,7 +457,6 @@ registration_workflows:
         identity_matrix: $FSLDIR/etc/flirtsch/ident.mat
         interpolation: sinc
         ref_mask: null
-        ref_mask_res-2: null
         ref_resolution: 2mm
       using:
       - ANTS
@@ -494,8 +494,6 @@ registration_workflows:
           func_reg_input_volume: 0
         input:
         - fmriprep_reference
-        reg_with_skull: false
-      input: brain
       interpolation: trilinear
       run: true
       using: FSL
@@ -596,11 +594,6 @@ surface_analysis:
     run: false
     surface_parcellation_template: /cpac_templates/Schaefer2018_200Parcels_17Networks_order.dlabel.nii
 timeseries_extraction:
-  connectivity_matrix:
-    measure:
-    - Pearson
-    using:
-    - Nilearn
   realignment: ROI_to_func
   run: true
   tse_roi_paths:

--- a/configs/p108_base-rbc_perturb-abcd_step-functional-registration_conn-afni_nuisance-true.yml
+++ b/configs/p108_base-rbc_perturb-abcd_step-functional-registration_conn-afni_nuisance-true.yml
@@ -310,6 +310,7 @@ nuisance_corrections:
     - true
     space: template
 pipeline_setup:
+  freesurfer_dir: /ocean/projects/med220004p/trogers1/many_pipelines/freesurfer/outputs/ABCD_all_subjects
   Amazon-AWS:
     aws_output_bucket_credentials: null
     s3_encryption: true
@@ -360,7 +361,7 @@ pipeline_setup:
     random_seed: 77742777
   working_directory:
     path: /outputs/working
-    remove_working_dir: true
+    remove_working_dir: false
 post_processing:
   spatial_smoothing:
     fwhm:
@@ -456,7 +457,6 @@ registration_workflows:
         identity_matrix: $FSLDIR/etc/flirtsch/ident.mat
         interpolation: sinc
         ref_mask: null
-        ref_mask_res-2: null
         ref_resolution: 2mm
       using:
       - ANTS
@@ -494,8 +494,6 @@ registration_workflows:
           func_reg_input_volume: 0
         input:
         - Selected_Functional_Volume
-        reg_with_skull: true
-      input: brain
       interpolation: spline
       run: true
       using: FSL
@@ -596,11 +594,6 @@ surface_analysis:
     run: false
     surface_parcellation_template: /cpac_templates/Schaefer2018_200Parcels_17Networks_order.dlabel.nii
 timeseries_extraction:
-  connectivity_matrix:
-    measure:
-    - Pearson
-    using:
-    - AFNI
   realignment: ROI_to_func
   run: true
   tse_roi_paths:

--- a/configs/p109_base-rbc_perturb-abcd_step-functional-registration_conn-afni_nuisance-false.yml
+++ b/configs/p109_base-rbc_perturb-abcd_step-functional-registration_conn-afni_nuisance-false.yml
@@ -310,6 +310,7 @@ nuisance_corrections:
     - false
     space: template
 pipeline_setup:
+  freesurfer_dir: /ocean/projects/med220004p/trogers1/many_pipelines/freesurfer/outputs/ABCD_all_subjects
   Amazon-AWS:
     aws_output_bucket_credentials: null
     s3_encryption: true
@@ -360,7 +361,7 @@ pipeline_setup:
     random_seed: 77742777
   working_directory:
     path: /outputs/working
-    remove_working_dir: true
+    remove_working_dir: false
 post_processing:
   spatial_smoothing:
     fwhm:
@@ -456,7 +457,6 @@ registration_workflows:
         identity_matrix: $FSLDIR/etc/flirtsch/ident.mat
         interpolation: sinc
         ref_mask: null
-        ref_mask_res-2: null
         ref_resolution: 2mm
       using:
       - ANTS
@@ -494,8 +494,6 @@ registration_workflows:
           func_reg_input_volume: 0
         input:
         - Selected_Functional_Volume
-        reg_with_skull: true
-      input: brain
       interpolation: spline
       run: true
       using: FSL
@@ -596,11 +594,6 @@ surface_analysis:
     run: false
     surface_parcellation_template: /cpac_templates/Schaefer2018_200Parcels_17Networks_order.dlabel.nii
 timeseries_extraction:
-  connectivity_matrix:
-    measure:
-    - Pearson
-    using:
-    - AFNI
   realignment: ROI_to_func
   run: true
   tse_roi_paths:

--- a/configs/p110_base-rbc_perturb-abcd_step-functional-registration_conn-nilearn_nuisance-true.yml
+++ b/configs/p110_base-rbc_perturb-abcd_step-functional-registration_conn-nilearn_nuisance-true.yml
@@ -310,6 +310,7 @@ nuisance_corrections:
     - true
     space: template
 pipeline_setup:
+  freesurfer_dir: /ocean/projects/med220004p/trogers1/many_pipelines/freesurfer/outputs/ABCD_all_subjects
   Amazon-AWS:
     aws_output_bucket_credentials: null
     s3_encryption: true
@@ -360,7 +361,7 @@ pipeline_setup:
     random_seed: 77742777
   working_directory:
     path: /outputs/working
-    remove_working_dir: true
+    remove_working_dir: false
 post_processing:
   spatial_smoothing:
     fwhm:
@@ -456,7 +457,6 @@ registration_workflows:
         identity_matrix: $FSLDIR/etc/flirtsch/ident.mat
         interpolation: sinc
         ref_mask: null
-        ref_mask_res-2: null
         ref_resolution: 2mm
       using:
       - ANTS
@@ -494,8 +494,6 @@ registration_workflows:
           func_reg_input_volume: 0
         input:
         - Selected_Functional_Volume
-        reg_with_skull: true
-      input: brain
       interpolation: spline
       run: true
       using: FSL
@@ -596,11 +594,6 @@ surface_analysis:
     run: false
     surface_parcellation_template: /cpac_templates/Schaefer2018_200Parcels_17Networks_order.dlabel.nii
 timeseries_extraction:
-  connectivity_matrix:
-    measure:
-    - Pearson
-    using:
-    - Nilearn
   realignment: ROI_to_func
   run: true
   tse_roi_paths:

--- a/configs/p111_base-rbc_perturb-abcd_step-functional-registration_conn-nilearn_nuisance-false.yml
+++ b/configs/p111_base-rbc_perturb-abcd_step-functional-registration_conn-nilearn_nuisance-false.yml
@@ -310,6 +310,7 @@ nuisance_corrections:
     - false
     space: template
 pipeline_setup:
+  freesurfer_dir: /ocean/projects/med220004p/trogers1/many_pipelines/freesurfer/outputs/ABCD_all_subjects
   Amazon-AWS:
     aws_output_bucket_credentials: null
     s3_encryption: true
@@ -360,7 +361,7 @@ pipeline_setup:
     random_seed: 77742777
   working_directory:
     path: /outputs/working
-    remove_working_dir: true
+    remove_working_dir: false
 post_processing:
   spatial_smoothing:
     fwhm:
@@ -456,7 +457,6 @@ registration_workflows:
         identity_matrix: $FSLDIR/etc/flirtsch/ident.mat
         interpolation: sinc
         ref_mask: null
-        ref_mask_res-2: null
         ref_resolution: 2mm
       using:
       - ANTS
@@ -494,8 +494,6 @@ registration_workflows:
           func_reg_input_volume: 0
         input:
         - Selected_Functional_Volume
-        reg_with_skull: true
-      input: brain
       interpolation: spline
       run: true
       using: FSL
@@ -596,11 +594,6 @@ surface_analysis:
     run: false
     surface_parcellation_template: /cpac_templates/Schaefer2018_200Parcels_17Networks_order.dlabel.nii
 timeseries_extraction:
-  connectivity_matrix:
-    measure:
-    - Pearson
-    using:
-    - Nilearn
   realignment: ROI_to_func
   run: true
   tse_roi_paths:

--- a/configs/p112_base-rbc_perturb-ccs_step-structural-masking_conn-afni_nuisance-true.yml
+++ b/configs/p112_base-rbc_perturb-ccs_step-structural-masking_conn-afni_nuisance-true.yml
@@ -312,6 +312,7 @@ nuisance_corrections:
     - true
     space: template
 pipeline_setup:
+  freesurfer_dir: /ocean/projects/med220004p/trogers1/many_pipelines/freesurfer/outputs/ABCD_all_subjects
   Amazon-AWS:
     aws_output_bucket_credentials: null
     s3_encryption: true
@@ -362,7 +363,7 @@ pipeline_setup:
     random_seed: 77742777
   working_directory:
     path: /outputs/working
-    remove_working_dir: true
+    remove_working_dir: false
 post_processing:
   spatial_smoothing:
     fwhm:
@@ -458,7 +459,6 @@ registration_workflows:
         identity_matrix: $FSLDIR/etc/flirtsch/ident.mat
         interpolation: sinc
         ref_mask: null
-        ref_mask_res-2: null
         ref_resolution: 2mm
       using:
       - ANTS
@@ -496,8 +496,6 @@ registration_workflows:
           func_reg_input_volume: 0
         input:
         - fmriprep_reference
-        reg_with_skull: false
-      input: brain
       interpolation: trilinear
       run: true
       using: FSL
@@ -598,11 +596,6 @@ surface_analysis:
     run: false
     surface_parcellation_template: /cpac_templates/Schaefer2018_200Parcels_17Networks_order.dlabel.nii
 timeseries_extraction:
-  connectivity_matrix:
-    measure:
-    - Pearson
-    using:
-    - AFNI
   realignment: ROI_to_func
   run: true
   tse_roi_paths:

--- a/configs/p113_base-rbc_perturb-ccs_step-structural-masking_conn-afni_nuisance-false.yml
+++ b/configs/p113_base-rbc_perturb-ccs_step-structural-masking_conn-afni_nuisance-false.yml
@@ -312,6 +312,7 @@ nuisance_corrections:
     - false
     space: template
 pipeline_setup:
+  freesurfer_dir: /ocean/projects/med220004p/trogers1/many_pipelines/freesurfer/outputs/ABCD_all_subjects
   Amazon-AWS:
     aws_output_bucket_credentials: null
     s3_encryption: true
@@ -362,7 +363,7 @@ pipeline_setup:
     random_seed: 77742777
   working_directory:
     path: /outputs/working
-    remove_working_dir: true
+    remove_working_dir: false
 post_processing:
   spatial_smoothing:
     fwhm:
@@ -458,7 +459,6 @@ registration_workflows:
         identity_matrix: $FSLDIR/etc/flirtsch/ident.mat
         interpolation: sinc
         ref_mask: null
-        ref_mask_res-2: null
         ref_resolution: 2mm
       using:
       - ANTS
@@ -496,8 +496,6 @@ registration_workflows:
           func_reg_input_volume: 0
         input:
         - fmriprep_reference
-        reg_with_skull: false
-      input: brain
       interpolation: trilinear
       run: true
       using: FSL
@@ -598,11 +596,6 @@ surface_analysis:
     run: false
     surface_parcellation_template: /cpac_templates/Schaefer2018_200Parcels_17Networks_order.dlabel.nii
 timeseries_extraction:
-  connectivity_matrix:
-    measure:
-    - Pearson
-    using:
-    - AFNI
   realignment: ROI_to_func
   run: true
   tse_roi_paths:

--- a/configs/p114_base-rbc_perturb-ccs_step-structural-masking_conn-nilearn_nuisance-true.yml
+++ b/configs/p114_base-rbc_perturb-ccs_step-structural-masking_conn-nilearn_nuisance-true.yml
@@ -312,6 +312,7 @@ nuisance_corrections:
     - true
     space: template
 pipeline_setup:
+  freesurfer_dir: /ocean/projects/med220004p/trogers1/many_pipelines/freesurfer/outputs/ABCD_all_subjects
   Amazon-AWS:
     aws_output_bucket_credentials: null
     s3_encryption: true
@@ -362,7 +363,7 @@ pipeline_setup:
     random_seed: 77742777
   working_directory:
     path: /outputs/working
-    remove_working_dir: true
+    remove_working_dir: false
 post_processing:
   spatial_smoothing:
     fwhm:
@@ -458,7 +459,6 @@ registration_workflows:
         identity_matrix: $FSLDIR/etc/flirtsch/ident.mat
         interpolation: sinc
         ref_mask: null
-        ref_mask_res-2: null
         ref_resolution: 2mm
       using:
       - ANTS
@@ -496,8 +496,6 @@ registration_workflows:
           func_reg_input_volume: 0
         input:
         - fmriprep_reference
-        reg_with_skull: false
-      input: brain
       interpolation: trilinear
       run: true
       using: FSL
@@ -598,11 +596,6 @@ surface_analysis:
     run: false
     surface_parcellation_template: /cpac_templates/Schaefer2018_200Parcels_17Networks_order.dlabel.nii
 timeseries_extraction:
-  connectivity_matrix:
-    measure:
-    - Pearson
-    using:
-    - Nilearn
   realignment: ROI_to_func
   run: true
   tse_roi_paths:

--- a/configs/p115_base-rbc_perturb-ccs_step-structural-masking_conn-nilearn_nuisance-false.yml
+++ b/configs/p115_base-rbc_perturb-ccs_step-structural-masking_conn-nilearn_nuisance-false.yml
@@ -312,6 +312,7 @@ nuisance_corrections:
     - false
     space: template
 pipeline_setup:
+  freesurfer_dir: /ocean/projects/med220004p/trogers1/many_pipelines/freesurfer/outputs/ABCD_all_subjects
   Amazon-AWS:
     aws_output_bucket_credentials: null
     s3_encryption: true
@@ -362,7 +363,7 @@ pipeline_setup:
     random_seed: 77742777
   working_directory:
     path: /outputs/working
-    remove_working_dir: true
+    remove_working_dir: false
 post_processing:
   spatial_smoothing:
     fwhm:
@@ -458,7 +459,6 @@ registration_workflows:
         identity_matrix: $FSLDIR/etc/flirtsch/ident.mat
         interpolation: sinc
         ref_mask: null
-        ref_mask_res-2: null
         ref_resolution: 2mm
       using:
       - ANTS
@@ -496,8 +496,6 @@ registration_workflows:
           func_reg_input_volume: 0
         input:
         - fmriprep_reference
-        reg_with_skull: false
-      input: brain
       interpolation: trilinear
       run: true
       using: FSL
@@ -598,11 +596,6 @@ surface_analysis:
     run: false
     surface_parcellation_template: /cpac_templates/Schaefer2018_200Parcels_17Networks_order.dlabel.nii
 timeseries_extraction:
-  connectivity_matrix:
-    measure:
-    - Pearson
-    using:
-    - Nilearn
   realignment: ROI_to_func
   run: true
   tse_roi_paths:

--- a/configs/p116_base-rbc_perturb-ccs_step-structural-registration_conn-afni_nuisance-true.yml
+++ b/configs/p116_base-rbc_perturb-ccs_step-structural-registration_conn-afni_nuisance-true.yml
@@ -310,6 +310,7 @@ nuisance_corrections:
     - true
     space: template
 pipeline_setup:
+  freesurfer_dir: /ocean/projects/med220004p/trogers1/many_pipelines/freesurfer/outputs/ABCD_all_subjects
   Amazon-AWS:
     aws_output_bucket_credentials: null
     s3_encryption: true
@@ -360,7 +361,7 @@ pipeline_setup:
     random_seed: 77742777
   working_directory:
     path: /outputs/working
-    remove_working_dir: true
+    remove_working_dir: false
 post_processing:
   spatial_smoothing:
     fwhm:
@@ -388,7 +389,6 @@ registration_workflows:
     T1w_template: $FSLDIR/data/standard/MNI152_T1_${resolution_for_anat}.nii.gz
     overwrite_transform:
       run: false
-      using: FSL
     reg_with_skull: false
     registration:
       ANTs:
@@ -456,10 +456,9 @@ registration_workflows:
         identity_matrix: $FSLDIR/etc/flirtsch/ident.mat
         interpolation: trilinear
         ref_mask: $FSLDIR/data/standard/MNI152_T1_${resolution_for_anat}_brain_mask_dil.nii.gz
-        ref_mask_res-2: $FSLDIR/data/standard/MNI152_T1_2mm_brain_mask_dil.nii.gz
         ref_resolution: 2mm
       using:
-      - FSL
+      - ANTS
     resolution_for_anat: 2mm
     run: true
   functional_registration:
@@ -494,8 +493,6 @@ registration_workflows:
           func_reg_input_volume: 0
         input:
         - fmriprep_reference
-        reg_with_skull: false
-      input: brain
       interpolation: trilinear
       run: true
       using: FSL
@@ -596,11 +593,6 @@ surface_analysis:
     run: false
     surface_parcellation_template: /cpac_templates/Schaefer2018_200Parcels_17Networks_order.dlabel.nii
 timeseries_extraction:
-  connectivity_matrix:
-    measure:
-    - Pearson
-    using:
-    - AFNI
   realignment: ROI_to_func
   run: true
   tse_roi_paths:

--- a/configs/p117_base-rbc_perturb-ccs_step-structural-registration_conn-afni_nuisance-false.yml
+++ b/configs/p117_base-rbc_perturb-ccs_step-structural-registration_conn-afni_nuisance-false.yml
@@ -310,6 +310,7 @@ nuisance_corrections:
     - false
     space: template
 pipeline_setup:
+  freesurfer_dir: /ocean/projects/med220004p/trogers1/many_pipelines/freesurfer/outputs/ABCD_all_subjects
   Amazon-AWS:
     aws_output_bucket_credentials: null
     s3_encryption: true
@@ -360,7 +361,7 @@ pipeline_setup:
     random_seed: 77742777
   working_directory:
     path: /outputs/working
-    remove_working_dir: true
+    remove_working_dir: false
 post_processing:
   spatial_smoothing:
     fwhm:
@@ -388,7 +389,6 @@ registration_workflows:
     T1w_template: $FSLDIR/data/standard/MNI152_T1_${resolution_for_anat}.nii.gz
     overwrite_transform:
       run: false
-      using: FSL
     reg_with_skull: false
     registration:
       ANTs:
@@ -456,10 +456,9 @@ registration_workflows:
         identity_matrix: $FSLDIR/etc/flirtsch/ident.mat
         interpolation: trilinear
         ref_mask: $FSLDIR/data/standard/MNI152_T1_${resolution_for_anat}_brain_mask_dil.nii.gz
-        ref_mask_res-2: $FSLDIR/data/standard/MNI152_T1_2mm_brain_mask_dil.nii.gz
         ref_resolution: 2mm
       using:
-      - FSL
+      - ANTS
     resolution_for_anat: 2mm
     run: true
   functional_registration:
@@ -494,8 +493,6 @@ registration_workflows:
           func_reg_input_volume: 0
         input:
         - fmriprep_reference
-        reg_with_skull: false
-      input: brain
       interpolation: trilinear
       run: true
       using: FSL
@@ -596,11 +593,6 @@ surface_analysis:
     run: false
     surface_parcellation_template: /cpac_templates/Schaefer2018_200Parcels_17Networks_order.dlabel.nii
 timeseries_extraction:
-  connectivity_matrix:
-    measure:
-    - Pearson
-    using:
-    - AFNI
   realignment: ROI_to_func
   run: true
   tse_roi_paths:

--- a/configs/p118_base-rbc_perturb-ccs_step-structural-registration_conn-nilearn_nuisance-true.yml
+++ b/configs/p118_base-rbc_perturb-ccs_step-structural-registration_conn-nilearn_nuisance-true.yml
@@ -310,6 +310,7 @@ nuisance_corrections:
     - true
     space: template
 pipeline_setup:
+  freesurfer_dir: /ocean/projects/med220004p/trogers1/many_pipelines/freesurfer/outputs/ABCD_all_subjects
   Amazon-AWS:
     aws_output_bucket_credentials: null
     s3_encryption: true
@@ -360,7 +361,7 @@ pipeline_setup:
     random_seed: 77742777
   working_directory:
     path: /outputs/working
-    remove_working_dir: true
+    remove_working_dir: false
 post_processing:
   spatial_smoothing:
     fwhm:
@@ -388,7 +389,6 @@ registration_workflows:
     T1w_template: $FSLDIR/data/standard/MNI152_T1_${resolution_for_anat}.nii.gz
     overwrite_transform:
       run: false
-      using: FSL
     reg_with_skull: false
     registration:
       ANTs:
@@ -456,10 +456,9 @@ registration_workflows:
         identity_matrix: $FSLDIR/etc/flirtsch/ident.mat
         interpolation: trilinear
         ref_mask: $FSLDIR/data/standard/MNI152_T1_${resolution_for_anat}_brain_mask_dil.nii.gz
-        ref_mask_res-2: $FSLDIR/data/standard/MNI152_T1_2mm_brain_mask_dil.nii.gz
         ref_resolution: 2mm
       using:
-      - FSL
+      - ANTS
     resolution_for_anat: 2mm
     run: true
   functional_registration:
@@ -494,8 +493,6 @@ registration_workflows:
           func_reg_input_volume: 0
         input:
         - fmriprep_reference
-        reg_with_skull: false
-      input: brain
       interpolation: trilinear
       run: true
       using: FSL
@@ -596,11 +593,6 @@ surface_analysis:
     run: false
     surface_parcellation_template: /cpac_templates/Schaefer2018_200Parcels_17Networks_order.dlabel.nii
 timeseries_extraction:
-  connectivity_matrix:
-    measure:
-    - Pearson
-    using:
-    - Nilearn
   realignment: ROI_to_func
   run: true
   tse_roi_paths:

--- a/configs/p119_base-rbc_perturb-ccs_step-structural-registration_conn-nilearn_nuisance-false.yml
+++ b/configs/p119_base-rbc_perturb-ccs_step-structural-registration_conn-nilearn_nuisance-false.yml
@@ -310,6 +310,7 @@ nuisance_corrections:
     - false
     space: template
 pipeline_setup:
+  freesurfer_dir: /ocean/projects/med220004p/trogers1/many_pipelines/freesurfer/outputs/ABCD_all_subjects
   Amazon-AWS:
     aws_output_bucket_credentials: null
     s3_encryption: true
@@ -360,7 +361,7 @@ pipeline_setup:
     random_seed: 77742777
   working_directory:
     path: /outputs/working
-    remove_working_dir: true
+    remove_working_dir: false
 post_processing:
   spatial_smoothing:
     fwhm:
@@ -388,7 +389,6 @@ registration_workflows:
     T1w_template: $FSLDIR/data/standard/MNI152_T1_${resolution_for_anat}.nii.gz
     overwrite_transform:
       run: false
-      using: FSL
     reg_with_skull: false
     registration:
       ANTs:
@@ -456,10 +456,9 @@ registration_workflows:
         identity_matrix: $FSLDIR/etc/flirtsch/ident.mat
         interpolation: trilinear
         ref_mask: $FSLDIR/data/standard/MNI152_T1_${resolution_for_anat}_brain_mask_dil.nii.gz
-        ref_mask_res-2: $FSLDIR/data/standard/MNI152_T1_2mm_brain_mask_dil.nii.gz
         ref_resolution: 2mm
       using:
-      - FSL
+      - ANTS
     resolution_for_anat: 2mm
     run: true
   functional_registration:
@@ -494,8 +493,6 @@ registration_workflows:
           func_reg_input_volume: 0
         input:
         - fmriprep_reference
-        reg_with_skull: false
-      input: brain
       interpolation: trilinear
       run: true
       using: FSL
@@ -596,11 +593,6 @@ surface_analysis:
     run: false
     surface_parcellation_template: /cpac_templates/Schaefer2018_200Parcels_17Networks_order.dlabel.nii
 timeseries_extraction:
-  connectivity_matrix:
-    measure:
-    - Pearson
-    using:
-    - Nilearn
   realignment: ROI_to_func
   run: true
   tse_roi_paths:

--- a/configs/p120_base-rbc_perturb-ccs_step-functional-masking_conn-afni_nuisance-true.yml
+++ b/configs/p120_base-rbc_perturb-ccs_step-functional-masking_conn-afni_nuisance-true.yml
@@ -310,6 +310,7 @@ nuisance_corrections:
     - true
     space: template
 pipeline_setup:
+  freesurfer_dir: /ocean/projects/med220004p/trogers1/many_pipelines/freesurfer/outputs/ABCD_all_subjects
   Amazon-AWS:
     aws_output_bucket_credentials: null
     s3_encryption: true
@@ -360,7 +361,7 @@ pipeline_setup:
     random_seed: 77742777
   working_directory:
     path: /outputs/working
-    remove_working_dir: true
+    remove_working_dir: false
 post_processing:
   spatial_smoothing:
     fwhm:
@@ -456,7 +457,6 @@ registration_workflows:
         identity_matrix: $FSLDIR/etc/flirtsch/ident.mat
         interpolation: sinc
         ref_mask: null
-        ref_mask_res-2: null
         ref_resolution: 2mm
       using:
       - ANTS
@@ -494,8 +494,6 @@ registration_workflows:
           func_reg_input_volume: 0
         input:
         - fmriprep_reference
-        reg_with_skull: false
-      input: brain
       interpolation: trilinear
       run: true
       using: FSL
@@ -596,11 +594,6 @@ surface_analysis:
     run: false
     surface_parcellation_template: /cpac_templates/Schaefer2018_200Parcels_17Networks_order.dlabel.nii
 timeseries_extraction:
-  connectivity_matrix:
-    measure:
-    - Pearson
-    using:
-    - AFNI
   realignment: ROI_to_func
   run: true
   tse_roi_paths:

--- a/configs/p121_base-rbc_perturb-ccs_step-functional-masking_conn-afni_nuisance-false.yml
+++ b/configs/p121_base-rbc_perturb-ccs_step-functional-masking_conn-afni_nuisance-false.yml
@@ -310,6 +310,7 @@ nuisance_corrections:
     - false
     space: template
 pipeline_setup:
+  freesurfer_dir: /ocean/projects/med220004p/trogers1/many_pipelines/freesurfer/outputs/ABCD_all_subjects
   Amazon-AWS:
     aws_output_bucket_credentials: null
     s3_encryption: true
@@ -360,7 +361,7 @@ pipeline_setup:
     random_seed: 77742777
   working_directory:
     path: /outputs/working
-    remove_working_dir: true
+    remove_working_dir: false
 post_processing:
   spatial_smoothing:
     fwhm:
@@ -456,7 +457,6 @@ registration_workflows:
         identity_matrix: $FSLDIR/etc/flirtsch/ident.mat
         interpolation: sinc
         ref_mask: null
-        ref_mask_res-2: null
         ref_resolution: 2mm
       using:
       - ANTS
@@ -494,8 +494,6 @@ registration_workflows:
           func_reg_input_volume: 0
         input:
         - fmriprep_reference
-        reg_with_skull: false
-      input: brain
       interpolation: trilinear
       run: true
       using: FSL
@@ -596,11 +594,6 @@ surface_analysis:
     run: false
     surface_parcellation_template: /cpac_templates/Schaefer2018_200Parcels_17Networks_order.dlabel.nii
 timeseries_extraction:
-  connectivity_matrix:
-    measure:
-    - Pearson
-    using:
-    - AFNI
   realignment: ROI_to_func
   run: true
   tse_roi_paths:

--- a/configs/p122_base-rbc_perturb-ccs_step-functional-masking_conn-nilearn_nuisance-true.yml
+++ b/configs/p122_base-rbc_perturb-ccs_step-functional-masking_conn-nilearn_nuisance-true.yml
@@ -310,6 +310,7 @@ nuisance_corrections:
     - true
     space: template
 pipeline_setup:
+  freesurfer_dir: /ocean/projects/med220004p/trogers1/many_pipelines/freesurfer/outputs/ABCD_all_subjects
   Amazon-AWS:
     aws_output_bucket_credentials: null
     s3_encryption: true
@@ -360,7 +361,7 @@ pipeline_setup:
     random_seed: 77742777
   working_directory:
     path: /outputs/working
-    remove_working_dir: true
+    remove_working_dir: false
 post_processing:
   spatial_smoothing:
     fwhm:
@@ -456,7 +457,6 @@ registration_workflows:
         identity_matrix: $FSLDIR/etc/flirtsch/ident.mat
         interpolation: sinc
         ref_mask: null
-        ref_mask_res-2: null
         ref_resolution: 2mm
       using:
       - ANTS
@@ -494,8 +494,6 @@ registration_workflows:
           func_reg_input_volume: 0
         input:
         - fmriprep_reference
-        reg_with_skull: false
-      input: brain
       interpolation: trilinear
       run: true
       using: FSL
@@ -596,11 +594,6 @@ surface_analysis:
     run: false
     surface_parcellation_template: /cpac_templates/Schaefer2018_200Parcels_17Networks_order.dlabel.nii
 timeseries_extraction:
-  connectivity_matrix:
-    measure:
-    - Pearson
-    using:
-    - Nilearn
   realignment: ROI_to_func
   run: true
   tse_roi_paths:

--- a/configs/p123_base-rbc_perturb-ccs_step-functional-masking_conn-nilearn_nuisance-false.yml
+++ b/configs/p123_base-rbc_perturb-ccs_step-functional-masking_conn-nilearn_nuisance-false.yml
@@ -310,6 +310,7 @@ nuisance_corrections:
     - false
     space: template
 pipeline_setup:
+  freesurfer_dir: /ocean/projects/med220004p/trogers1/many_pipelines/freesurfer/outputs/ABCD_all_subjects
   Amazon-AWS:
     aws_output_bucket_credentials: null
     s3_encryption: true
@@ -360,7 +361,7 @@ pipeline_setup:
     random_seed: 77742777
   working_directory:
     path: /outputs/working
-    remove_working_dir: true
+    remove_working_dir: false
 post_processing:
   spatial_smoothing:
     fwhm:
@@ -456,7 +457,6 @@ registration_workflows:
         identity_matrix: $FSLDIR/etc/flirtsch/ident.mat
         interpolation: sinc
         ref_mask: null
-        ref_mask_res-2: null
         ref_resolution: 2mm
       using:
       - ANTS
@@ -494,8 +494,6 @@ registration_workflows:
           func_reg_input_volume: 0
         input:
         - fmriprep_reference
-        reg_with_skull: false
-      input: brain
       interpolation: trilinear
       run: true
       using: FSL
@@ -596,11 +594,6 @@ surface_analysis:
     run: false
     surface_parcellation_template: /cpac_templates/Schaefer2018_200Parcels_17Networks_order.dlabel.nii
 timeseries_extraction:
-  connectivity_matrix:
-    measure:
-    - Pearson
-    using:
-    - Nilearn
   realignment: ROI_to_func
   run: true
   tse_roi_paths:

--- a/configs/p124_base-rbc_perturb-ccs_step-functional-registration_conn-afni_nuisance-true.yml
+++ b/configs/p124_base-rbc_perturb-ccs_step-functional-registration_conn-afni_nuisance-true.yml
@@ -310,6 +310,7 @@ nuisance_corrections:
     - true
     space: template
 pipeline_setup:
+  freesurfer_dir: /ocean/projects/med220004p/trogers1/many_pipelines/freesurfer/outputs/ABCD_all_subjects
   Amazon-AWS:
     aws_output_bucket_credentials: null
     s3_encryption: true
@@ -360,7 +361,7 @@ pipeline_setup:
     random_seed: 77742777
   working_directory:
     path: /outputs/working
-    remove_working_dir: true
+    remove_working_dir: false
 post_processing:
   spatial_smoothing:
     fwhm:
@@ -456,7 +457,6 @@ registration_workflows:
         identity_matrix: $FSLDIR/etc/flirtsch/ident.mat
         interpolation: sinc
         ref_mask: null
-        ref_mask_res-2: null
         ref_resolution: 2mm
       using:
       - ANTS
@@ -494,8 +494,6 @@ registration_workflows:
           func_reg_input_volume: 7
         input:
         - Selected_Functional_Volume
-        reg_with_skull: false
-      input: brain
       interpolation: trilinear
       run: true
       using: FSL
@@ -596,11 +594,6 @@ surface_analysis:
     run: false
     surface_parcellation_template: /cpac_templates/Schaefer2018_200Parcels_17Networks_order.dlabel.nii
 timeseries_extraction:
-  connectivity_matrix:
-    measure:
-    - Pearson
-    using:
-    - AFNI
   realignment: ROI_to_func
   run: true
   tse_roi_paths:

--- a/configs/p125_base-rbc_perturb-ccs_step-functional-registration_conn-afni_nuisance-false.yml
+++ b/configs/p125_base-rbc_perturb-ccs_step-functional-registration_conn-afni_nuisance-false.yml
@@ -310,6 +310,7 @@ nuisance_corrections:
     - false
     space: template
 pipeline_setup:
+  freesurfer_dir: /ocean/projects/med220004p/trogers1/many_pipelines/freesurfer/outputs/ABCD_all_subjects
   Amazon-AWS:
     aws_output_bucket_credentials: null
     s3_encryption: true
@@ -360,7 +361,7 @@ pipeline_setup:
     random_seed: 77742777
   working_directory:
     path: /outputs/working
-    remove_working_dir: true
+    remove_working_dir: false
 post_processing:
   spatial_smoothing:
     fwhm:
@@ -456,7 +457,6 @@ registration_workflows:
         identity_matrix: $FSLDIR/etc/flirtsch/ident.mat
         interpolation: sinc
         ref_mask: null
-        ref_mask_res-2: null
         ref_resolution: 2mm
       using:
       - ANTS
@@ -494,8 +494,6 @@ registration_workflows:
           func_reg_input_volume: 7
         input:
         - Selected_Functional_Volume
-        reg_with_skull: false
-      input: brain
       interpolation: trilinear
       run: true
       using: FSL
@@ -596,11 +594,6 @@ surface_analysis:
     run: false
     surface_parcellation_template: /cpac_templates/Schaefer2018_200Parcels_17Networks_order.dlabel.nii
 timeseries_extraction:
-  connectivity_matrix:
-    measure:
-    - Pearson
-    using:
-    - AFNI
   realignment: ROI_to_func
   run: true
   tse_roi_paths:

--- a/configs/p126_base-rbc_perturb-ccs_step-functional-registration_conn-nilearn_nuisance-true.yml
+++ b/configs/p126_base-rbc_perturb-ccs_step-functional-registration_conn-nilearn_nuisance-true.yml
@@ -310,6 +310,7 @@ nuisance_corrections:
     - true
     space: template
 pipeline_setup:
+  freesurfer_dir: /ocean/projects/med220004p/trogers1/many_pipelines/freesurfer/outputs/ABCD_all_subjects
   Amazon-AWS:
     aws_output_bucket_credentials: null
     s3_encryption: true
@@ -360,7 +361,7 @@ pipeline_setup:
     random_seed: 77742777
   working_directory:
     path: /outputs/working
-    remove_working_dir: true
+    remove_working_dir: false
 post_processing:
   spatial_smoothing:
     fwhm:
@@ -456,7 +457,6 @@ registration_workflows:
         identity_matrix: $FSLDIR/etc/flirtsch/ident.mat
         interpolation: sinc
         ref_mask: null
-        ref_mask_res-2: null
         ref_resolution: 2mm
       using:
       - ANTS
@@ -494,8 +494,6 @@ registration_workflows:
           func_reg_input_volume: 7
         input:
         - Selected_Functional_Volume
-        reg_with_skull: false
-      input: brain
       interpolation: trilinear
       run: true
       using: FSL
@@ -596,11 +594,6 @@ surface_analysis:
     run: false
     surface_parcellation_template: /cpac_templates/Schaefer2018_200Parcels_17Networks_order.dlabel.nii
 timeseries_extraction:
-  connectivity_matrix:
-    measure:
-    - Pearson
-    using:
-    - Nilearn
   realignment: ROI_to_func
   run: true
   tse_roi_paths:

--- a/configs/p127_base-rbc_perturb-ccs_step-functional-registration_conn-nilearn_nuisance-false.yml
+++ b/configs/p127_base-rbc_perturb-ccs_step-functional-registration_conn-nilearn_nuisance-false.yml
@@ -310,6 +310,7 @@ nuisance_corrections:
     - false
     space: template
 pipeline_setup:
+  freesurfer_dir: /ocean/projects/med220004p/trogers1/many_pipelines/freesurfer/outputs/ABCD_all_subjects
   Amazon-AWS:
     aws_output_bucket_credentials: null
     s3_encryption: true
@@ -360,7 +361,7 @@ pipeline_setup:
     random_seed: 77742777
   working_directory:
     path: /outputs/working
-    remove_working_dir: true
+    remove_working_dir: false
 post_processing:
   spatial_smoothing:
     fwhm:
@@ -456,7 +457,6 @@ registration_workflows:
         identity_matrix: $FSLDIR/etc/flirtsch/ident.mat
         interpolation: sinc
         ref_mask: null
-        ref_mask_res-2: null
         ref_resolution: 2mm
       using:
       - ANTS
@@ -494,8 +494,6 @@ registration_workflows:
           func_reg_input_volume: 7
         input:
         - Selected_Functional_Volume
-        reg_with_skull: false
-      input: brain
       interpolation: trilinear
       run: true
       using: FSL
@@ -596,11 +594,6 @@ surface_analysis:
     run: false
     surface_parcellation_template: /cpac_templates/Schaefer2018_200Parcels_17Networks_order.dlabel.nii
 timeseries_extraction:
-  connectivity_matrix:
-    measure:
-    - Pearson
-    using:
-    - Nilearn
   realignment: ROI_to_func
   run: true
   tse_roi_paths:

--- a/configs/p128_base-rbc_perturb-fmriprep_step-structural-masking_conn-afni_nuisance-true.yml
+++ b/configs/p128_base-rbc_perturb-fmriprep_step-structural-masking_conn-afni_nuisance-true.yml
@@ -310,6 +310,7 @@ nuisance_corrections:
     - true
     space: template
 pipeline_setup:
+  freesurfer_dir: /ocean/projects/med220004p/trogers1/many_pipelines/freesurfer/outputs/ABCD_all_subjects
   Amazon-AWS:
     aws_output_bucket_credentials: null
     s3_encryption: true
@@ -360,7 +361,7 @@ pipeline_setup:
     random_seed: 77742777
   working_directory:
     path: /outputs/working
-    remove_working_dir: true
+    remove_working_dir: false
 post_processing:
   spatial_smoothing:
     fwhm:
@@ -456,7 +457,6 @@ registration_workflows:
         identity_matrix: $FSLDIR/etc/flirtsch/ident.mat
         interpolation: sinc
         ref_mask: null
-        ref_mask_res-2: null
         ref_resolution: 2mm
       using:
       - ANTS
@@ -493,9 +493,7 @@ registration_workflows:
         Selected Functional Volume:
           func_reg_input_volume: 0
         input:
-        - fmriprep_reference
-        reg_with_skull: false
-      input: brain
+        - fmriprep_references
       interpolation: trilinear
       run: true
       using: FSL
@@ -596,11 +594,6 @@ surface_analysis:
     run: false
     surface_parcellation_template: /cpac_templates/Schaefer2018_200Parcels_17Networks_order.dlabel.nii
 timeseries_extraction:
-  connectivity_matrix:
-    measure:
-    - Pearson
-    using:
-    - AFNI
   realignment: ROI_to_func
   run: true
   tse_roi_paths:

--- a/configs/p129_base-rbc_perturb-fmriprep_step-structural-masking_conn-afni_nuisance-false.yml
+++ b/configs/p129_base-rbc_perturb-fmriprep_step-structural-masking_conn-afni_nuisance-false.yml
@@ -310,6 +310,7 @@ nuisance_corrections:
     - false
     space: template
 pipeline_setup:
+  freesurfer_dir: /ocean/projects/med220004p/trogers1/many_pipelines/freesurfer/outputs/ABCD_all_subjects
   Amazon-AWS:
     aws_output_bucket_credentials: null
     s3_encryption: true
@@ -360,7 +361,7 @@ pipeline_setup:
     random_seed: 77742777
   working_directory:
     path: /outputs/working
-    remove_working_dir: true
+    remove_working_dir: false
 post_processing:
   spatial_smoothing:
     fwhm:
@@ -456,7 +457,6 @@ registration_workflows:
         identity_matrix: $FSLDIR/etc/flirtsch/ident.mat
         interpolation: sinc
         ref_mask: null
-        ref_mask_res-2: null
         ref_resolution: 2mm
       using:
       - ANTS
@@ -494,8 +494,6 @@ registration_workflows:
           func_reg_input_volume: 0
         input:
         - fmriprep_reference
-        reg_with_skull: false
-      input: brain
       interpolation: trilinear
       run: true
       using: FSL
@@ -596,11 +594,6 @@ surface_analysis:
     run: false
     surface_parcellation_template: /cpac_templates/Schaefer2018_200Parcels_17Networks_order.dlabel.nii
 timeseries_extraction:
-  connectivity_matrix:
-    measure:
-    - Pearson
-    using:
-    - AFNI
   realignment: ROI_to_func
   run: true
   tse_roi_paths:

--- a/configs/p130_base-rbc_perturb-fmriprep_step-structural-masking_conn-nilearn_nuisance-true.yml
+++ b/configs/p130_base-rbc_perturb-fmriprep_step-structural-masking_conn-nilearn_nuisance-true.yml
@@ -310,6 +310,7 @@ nuisance_corrections:
     - true
     space: template
 pipeline_setup:
+  freesurfer_dir: /ocean/projects/med220004p/trogers1/many_pipelines/freesurfer/outputs/ABCD_all_subjects
   Amazon-AWS:
     aws_output_bucket_credentials: null
     s3_encryption: true
@@ -360,7 +361,7 @@ pipeline_setup:
     random_seed: 77742777
   working_directory:
     path: /outputs/working
-    remove_working_dir: true
+    remove_working_dir: false
 post_processing:
   spatial_smoothing:
     fwhm:
@@ -456,7 +457,6 @@ registration_workflows:
         identity_matrix: $FSLDIR/etc/flirtsch/ident.mat
         interpolation: sinc
         ref_mask: null
-        ref_mask_res-2: null
         ref_resolution: 2mm
       using:
       - ANTS
@@ -494,8 +494,6 @@ registration_workflows:
           func_reg_input_volume: 0
         input:
         - fmriprep_reference
-        reg_with_skull: false
-      input: brain
       interpolation: trilinear
       run: true
       using: FSL
@@ -596,11 +594,6 @@ surface_analysis:
     run: false
     surface_parcellation_template: /cpac_templates/Schaefer2018_200Parcels_17Networks_order.dlabel.nii
 timeseries_extraction:
-  connectivity_matrix:
-    measure:
-    - Pearson
-    using:
-    - Nilearn
   realignment: ROI_to_func
   run: true
   tse_roi_paths:

--- a/configs/p131_base-rbc_perturb-fmriprep_step-structural-masking_conn-nilearn_nuisance-false.yml
+++ b/configs/p131_base-rbc_perturb-fmriprep_step-structural-masking_conn-nilearn_nuisance-false.yml
@@ -310,6 +310,7 @@ nuisance_corrections:
     - false
     space: template
 pipeline_setup:
+  freesurfer_dir: /ocean/projects/med220004p/trogers1/many_pipelines/freesurfer/outputs/ABCD_all_subjects
   Amazon-AWS:
     aws_output_bucket_credentials: null
     s3_encryption: true
@@ -360,7 +361,7 @@ pipeline_setup:
     random_seed: 77742777
   working_directory:
     path: /outputs/working
-    remove_working_dir: true
+    remove_working_dir: false
 post_processing:
   spatial_smoothing:
     fwhm:
@@ -456,7 +457,6 @@ registration_workflows:
         identity_matrix: $FSLDIR/etc/flirtsch/ident.mat
         interpolation: sinc
         ref_mask: null
-        ref_mask_res-2: null
         ref_resolution: 2mm
       using:
       - ANTS
@@ -494,8 +494,6 @@ registration_workflows:
           func_reg_input_volume: 0
         input:
         - fmriprep_reference
-        reg_with_skull: false
-      input: brain
       interpolation: trilinear
       run: true
       using: FSL
@@ -596,11 +594,6 @@ surface_analysis:
     run: false
     surface_parcellation_template: /cpac_templates/Schaefer2018_200Parcels_17Networks_order.dlabel.nii
 timeseries_extraction:
-  connectivity_matrix:
-    measure:
-    - Pearson
-    using:
-    - Nilearn
   realignment: ROI_to_func
   run: true
   tse_roi_paths:

--- a/configs/p132_base-rbc_perturb-fmriprep_step-structural-registration_conn-afni_nuisance-true.yml
+++ b/configs/p132_base-rbc_perturb-fmriprep_step-structural-registration_conn-afni_nuisance-true.yml
@@ -310,6 +310,7 @@ nuisance_corrections:
     - true
     space: template
 pipeline_setup:
+  freesurfer_dir: /ocean/projects/med220004p/trogers1/many_pipelines/freesurfer/outputs/ABCD_all_subjects
   Amazon-AWS:
     aws_output_bucket_credentials: null
     s3_encryption: true
@@ -360,7 +361,7 @@ pipeline_setup:
     random_seed: 77742777
   working_directory:
     path: /outputs/working
-    remove_working_dir: true
+    remove_working_dir: false
 post_processing:
   spatial_smoothing:
     fwhm:
@@ -456,7 +457,6 @@ registration_workflows:
         identity_matrix: $FSLDIR/etc/flirtsch/ident.mat
         interpolation: sinc
         ref_mask: null
-        ref_mask_res-2: null
         ref_resolution: 2mm
       using:
       - ANTS
@@ -494,8 +494,6 @@ registration_workflows:
           func_reg_input_volume: 0
         input:
         - fmriprep_reference
-        reg_with_skull: false
-      input: brain
       interpolation: trilinear
       run: true
       using: FSL
@@ -596,11 +594,6 @@ surface_analysis:
     run: false
     surface_parcellation_template: /cpac_templates/Schaefer2018_200Parcels_17Networks_order.dlabel.nii
 timeseries_extraction:
-  connectivity_matrix:
-    measure:
-    - Pearson
-    using:
-    - AFNI
   realignment: ROI_to_func
   run: true
   tse_roi_paths:

--- a/configs/p133_base-rbc_perturb-fmriprep_step-structural-registration_conn-afni_nuisance-false.yml
+++ b/configs/p133_base-rbc_perturb-fmriprep_step-structural-registration_conn-afni_nuisance-false.yml
@@ -310,6 +310,7 @@ nuisance_corrections:
     - false
     space: template
 pipeline_setup:
+  freesurfer_dir: /ocean/projects/med220004p/trogers1/many_pipelines/freesurfer/outputs/ABCD_all_subjects
   Amazon-AWS:
     aws_output_bucket_credentials: null
     s3_encryption: true
@@ -360,7 +361,7 @@ pipeline_setup:
     random_seed: 77742777
   working_directory:
     path: /outputs/working
-    remove_working_dir: true
+    remove_working_dir: false
 post_processing:
   spatial_smoothing:
     fwhm:
@@ -456,7 +457,6 @@ registration_workflows:
         identity_matrix: $FSLDIR/etc/flirtsch/ident.mat
         interpolation: sinc
         ref_mask: null
-        ref_mask_res-2: null
         ref_resolution: 2mm
       using:
       - ANTS
@@ -494,8 +494,6 @@ registration_workflows:
           func_reg_input_volume: 0
         input:
         - fmriprep_reference
-        reg_with_skull: false
-      input: brain
       interpolation: trilinear
       run: true
       using: FSL
@@ -596,11 +594,6 @@ surface_analysis:
     run: false
     surface_parcellation_template: /cpac_templates/Schaefer2018_200Parcels_17Networks_order.dlabel.nii
 timeseries_extraction:
-  connectivity_matrix:
-    measure:
-    - Pearson
-    using:
-    - AFNI
   realignment: ROI_to_func
   run: true
   tse_roi_paths:

--- a/configs/p134_base-rbc_perturb-fmriprep_step-structural-registration_conn-nilearn_nuisance-true.yml
+++ b/configs/p134_base-rbc_perturb-fmriprep_step-structural-registration_conn-nilearn_nuisance-true.yml
@@ -310,6 +310,7 @@ nuisance_corrections:
     - true
     space: template
 pipeline_setup:
+  freesurfer_dir: /ocean/projects/med220004p/trogers1/many_pipelines/freesurfer/outputs/ABCD_all_subjects
   Amazon-AWS:
     aws_output_bucket_credentials: null
     s3_encryption: true
@@ -360,7 +361,7 @@ pipeline_setup:
     random_seed: 77742777
   working_directory:
     path: /outputs/working
-    remove_working_dir: true
+    remove_working_dir: false
 post_processing:
   spatial_smoothing:
     fwhm:
@@ -456,7 +457,6 @@ registration_workflows:
         identity_matrix: $FSLDIR/etc/flirtsch/ident.mat
         interpolation: sinc
         ref_mask: null
-        ref_mask_res-2: null
         ref_resolution: 2mm
       using:
       - ANTS
@@ -494,8 +494,6 @@ registration_workflows:
           func_reg_input_volume: 0
         input:
         - fmriprep_reference
-        reg_with_skull: false
-      input: brain
       interpolation: trilinear
       run: true
       using: FSL
@@ -596,11 +594,6 @@ surface_analysis:
     run: false
     surface_parcellation_template: /cpac_templates/Schaefer2018_200Parcels_17Networks_order.dlabel.nii
 timeseries_extraction:
-  connectivity_matrix:
-    measure:
-    - Pearson
-    using:
-    - Nilearn
   realignment: ROI_to_func
   run: true
   tse_roi_paths:

--- a/configs/p135_base-rbc_perturb-fmriprep_step-structural-registration_conn-nilearn_nuisance-false.yml
+++ b/configs/p135_base-rbc_perturb-fmriprep_step-structural-registration_conn-nilearn_nuisance-false.yml
@@ -310,6 +310,7 @@ nuisance_corrections:
     - false
     space: template
 pipeline_setup:
+  freesurfer_dir: /ocean/projects/med220004p/trogers1/many_pipelines/freesurfer/outputs/ABCD_all_subjects
   Amazon-AWS:
     aws_output_bucket_credentials: null
     s3_encryption: true
@@ -360,7 +361,7 @@ pipeline_setup:
     random_seed: 77742777
   working_directory:
     path: /outputs/working
-    remove_working_dir: true
+    remove_working_dir: false
 post_processing:
   spatial_smoothing:
     fwhm:
@@ -456,7 +457,6 @@ registration_workflows:
         identity_matrix: $FSLDIR/etc/flirtsch/ident.mat
         interpolation: sinc
         ref_mask: null
-        ref_mask_res-2: null
         ref_resolution: 2mm
       using:
       - ANTS
@@ -494,8 +494,6 @@ registration_workflows:
           func_reg_input_volume: 0
         input:
         - fmriprep_reference
-        reg_with_skull: false
-      input: brain
       interpolation: trilinear
       run: true
       using: FSL
@@ -596,11 +594,6 @@ surface_analysis:
     run: false
     surface_parcellation_template: /cpac_templates/Schaefer2018_200Parcels_17Networks_order.dlabel.nii
 timeseries_extraction:
-  connectivity_matrix:
-    measure:
-    - Pearson
-    using:
-    - Nilearn
   realignment: ROI_to_func
   run: true
   tse_roi_paths:

--- a/configs/p136_base-rbc_perturb-fmriprep_step-functional-masking_conn-afni_nuisance-true.yml
+++ b/configs/p136_base-rbc_perturb-fmriprep_step-functional-masking_conn-afni_nuisance-true.yml
@@ -310,6 +310,7 @@ nuisance_corrections:
     - true
     space: template
 pipeline_setup:
+  freesurfer_dir: /ocean/projects/med220004p/trogers1/many_pipelines/freesurfer/outputs/ABCD_all_subjects
   Amazon-AWS:
     aws_output_bucket_credentials: null
     s3_encryption: true
@@ -360,7 +361,7 @@ pipeline_setup:
     random_seed: 77742777
   working_directory:
     path: /outputs/working
-    remove_working_dir: true
+    remove_working_dir: false
 post_processing:
   spatial_smoothing:
     fwhm:
@@ -456,7 +457,6 @@ registration_workflows:
         identity_matrix: $FSLDIR/etc/flirtsch/ident.mat
         interpolation: sinc
         ref_mask: null
-        ref_mask_res-2: null
         ref_resolution: 2mm
       using:
       - ANTS
@@ -494,8 +494,6 @@ registration_workflows:
           func_reg_input_volume: 0
         input:
         - fmriprep_reference
-        reg_with_skull: false
-      input: brain
       interpolation: trilinear
       run: true
       using: FSL
@@ -596,11 +594,6 @@ surface_analysis:
     run: false
     surface_parcellation_template: /cpac_templates/Schaefer2018_200Parcels_17Networks_order.dlabel.nii
 timeseries_extraction:
-  connectivity_matrix:
-    measure:
-    - Pearson
-    using:
-    - AFNI
   realignment: ROI_to_func
   run: true
   tse_roi_paths:

--- a/configs/p137_base-rbc_perturb-fmriprep_step-functional-masking_conn-afni_nuisance-false.yml
+++ b/configs/p137_base-rbc_perturb-fmriprep_step-functional-masking_conn-afni_nuisance-false.yml
@@ -310,6 +310,7 @@ nuisance_corrections:
     - false
     space: template
 pipeline_setup:
+  freesurfer_dir: /ocean/projects/med220004p/trogers1/many_pipelines/freesurfer/outputs/ABCD_all_subjects
   Amazon-AWS:
     aws_output_bucket_credentials: null
     s3_encryption: true
@@ -360,7 +361,7 @@ pipeline_setup:
     random_seed: 77742777
   working_directory:
     path: /outputs/working
-    remove_working_dir: true
+    remove_working_dir: false
 post_processing:
   spatial_smoothing:
     fwhm:
@@ -456,7 +457,6 @@ registration_workflows:
         identity_matrix: $FSLDIR/etc/flirtsch/ident.mat
         interpolation: sinc
         ref_mask: null
-        ref_mask_res-2: null
         ref_resolution: 2mm
       using:
       - ANTS
@@ -494,8 +494,6 @@ registration_workflows:
           func_reg_input_volume: 0
         input:
         - fmriprep_reference
-        reg_with_skull: false
-      input: brain
       interpolation: trilinear
       run: true
       using: FSL
@@ -596,11 +594,6 @@ surface_analysis:
     run: false
     surface_parcellation_template: /cpac_templates/Schaefer2018_200Parcels_17Networks_order.dlabel.nii
 timeseries_extraction:
-  connectivity_matrix:
-    measure:
-    - Pearson
-    using:
-    - AFNI
   realignment: ROI_to_func
   run: true
   tse_roi_paths:

--- a/configs/p138_base-rbc_perturb-fmriprep_step-functional-masking_conn-nilearn_nuisance-true.yml
+++ b/configs/p138_base-rbc_perturb-fmriprep_step-functional-masking_conn-nilearn_nuisance-true.yml
@@ -310,6 +310,7 @@ nuisance_corrections:
     - true
     space: template
 pipeline_setup:
+  freesurfer_dir: /ocean/projects/med220004p/trogers1/many_pipelines/freesurfer/outputs/ABCD_all_subjects
   Amazon-AWS:
     aws_output_bucket_credentials: null
     s3_encryption: true
@@ -360,7 +361,7 @@ pipeline_setup:
     random_seed: 77742777
   working_directory:
     path: /outputs/working
-    remove_working_dir: true
+    remove_working_dir: false
 post_processing:
   spatial_smoothing:
     fwhm:
@@ -456,7 +457,6 @@ registration_workflows:
         identity_matrix: $FSLDIR/etc/flirtsch/ident.mat
         interpolation: sinc
         ref_mask: null
-        ref_mask_res-2: null
         ref_resolution: 2mm
       using:
       - ANTS
@@ -494,8 +494,6 @@ registration_workflows:
           func_reg_input_volume: 0
         input:
         - fmriprep_reference
-        reg_with_skull: false
-      input: brain
       interpolation: trilinear
       run: true
       using: FSL
@@ -596,11 +594,6 @@ surface_analysis:
     run: false
     surface_parcellation_template: /cpac_templates/Schaefer2018_200Parcels_17Networks_order.dlabel.nii
 timeseries_extraction:
-  connectivity_matrix:
-    measure:
-    - Pearson
-    using:
-    - Nilearn
   realignment: ROI_to_func
   run: true
   tse_roi_paths:

--- a/configs/p139_base-rbc_perturb-fmriprep_step-functional-masking_conn-nilearn_nuisance-false.yml
+++ b/configs/p139_base-rbc_perturb-fmriprep_step-functional-masking_conn-nilearn_nuisance-false.yml
@@ -310,6 +310,7 @@ nuisance_corrections:
     - false
     space: template
 pipeline_setup:
+  freesurfer_dir: /ocean/projects/med220004p/trogers1/many_pipelines/freesurfer/outputs/ABCD_all_subjects
   Amazon-AWS:
     aws_output_bucket_credentials: null
     s3_encryption: true
@@ -360,7 +361,7 @@ pipeline_setup:
     random_seed: 77742777
   working_directory:
     path: /outputs/working
-    remove_working_dir: true
+    remove_working_dir: false
 post_processing:
   spatial_smoothing:
     fwhm:
@@ -456,7 +457,6 @@ registration_workflows:
         identity_matrix: $FSLDIR/etc/flirtsch/ident.mat
         interpolation: sinc
         ref_mask: null
-        ref_mask_res-2: null
         ref_resolution: 2mm
       using:
       - ANTS
@@ -494,8 +494,6 @@ registration_workflows:
           func_reg_input_volume: 0
         input:
         - fmriprep_reference
-        reg_with_skull: false
-      input: brain
       interpolation: trilinear
       run: true
       using: FSL
@@ -596,11 +594,6 @@ surface_analysis:
     run: false
     surface_parcellation_template: /cpac_templates/Schaefer2018_200Parcels_17Networks_order.dlabel.nii
 timeseries_extraction:
-  connectivity_matrix:
-    measure:
-    - Pearson
-    using:
-    - Nilearn
   realignment: ROI_to_func
   run: true
   tse_roi_paths:

--- a/configs/p140_base-rbc_perturb-fmriprep_step-functional-registration_conn-afni_nuisance-true.yml
+++ b/configs/p140_base-rbc_perturb-fmriprep_step-functional-registration_conn-afni_nuisance-true.yml
@@ -310,6 +310,7 @@ nuisance_corrections:
     - true
     space: template
 pipeline_setup:
+  freesurfer_dir: /ocean/projects/med220004p/trogers1/many_pipelines/freesurfer/outputs/ABCD_all_subjects
   Amazon-AWS:
     aws_output_bucket_credentials: null
     s3_encryption: true
@@ -360,7 +361,7 @@ pipeline_setup:
     random_seed: 77742777
   working_directory:
     path: /outputs/working
-    remove_working_dir: true
+    remove_working_dir: false
 post_processing:
   spatial_smoothing:
     fwhm:
@@ -456,7 +457,6 @@ registration_workflows:
         identity_matrix: $FSLDIR/etc/flirtsch/ident.mat
         interpolation: sinc
         ref_mask: null
-        ref_mask_res-2: null
         ref_resolution: 2mm
       using:
       - ANTS
@@ -494,8 +494,6 @@ registration_workflows:
           func_reg_input_volume: 0
         input:
         - fmriprep_reference
-        reg_with_skull: false
-      input: brain
       interpolation: trilinear
       run: true
       using: FSL
@@ -596,11 +594,6 @@ surface_analysis:
     run: false
     surface_parcellation_template: /cpac_templates/Schaefer2018_200Parcels_17Networks_order.dlabel.nii
 timeseries_extraction:
-  connectivity_matrix:
-    measure:
-    - Pearson
-    using:
-    - AFNI
   realignment: ROI_to_func
   run: true
   tse_roi_paths:

--- a/configs/p141_base-rbc_perturb-fmriprep_step-functional-registration_conn-afni_nuisance-false.yml
+++ b/configs/p141_base-rbc_perturb-fmriprep_step-functional-registration_conn-afni_nuisance-false.yml
@@ -310,6 +310,7 @@ nuisance_corrections:
     - false
     space: template
 pipeline_setup:
+  freesurfer_dir: /ocean/projects/med220004p/trogers1/many_pipelines/freesurfer/outputs/ABCD_all_subjects
   Amazon-AWS:
     aws_output_bucket_credentials: null
     s3_encryption: true
@@ -360,7 +361,7 @@ pipeline_setup:
     random_seed: 77742777
   working_directory:
     path: /outputs/working
-    remove_working_dir: true
+    remove_working_dir: false
 post_processing:
   spatial_smoothing:
     fwhm:
@@ -456,7 +457,6 @@ registration_workflows:
         identity_matrix: $FSLDIR/etc/flirtsch/ident.mat
         interpolation: sinc
         ref_mask: null
-        ref_mask_res-2: null
         ref_resolution: 2mm
       using:
       - ANTS
@@ -494,8 +494,6 @@ registration_workflows:
           func_reg_input_volume: 0
         input:
         - fmriprep_reference
-        reg_with_skull: false
-      input: brain
       interpolation: trilinear
       run: true
       using: FSL
@@ -596,11 +594,6 @@ surface_analysis:
     run: false
     surface_parcellation_template: /cpac_templates/Schaefer2018_200Parcels_17Networks_order.dlabel.nii
 timeseries_extraction:
-  connectivity_matrix:
-    measure:
-    - Pearson
-    using:
-    - AFNI
   realignment: ROI_to_func
   run: true
   tse_roi_paths:

--- a/configs/p142_base-rbc_perturb-fmriprep_step-functional-registration_conn-nilearn_nuisance-true.yml
+++ b/configs/p142_base-rbc_perturb-fmriprep_step-functional-registration_conn-nilearn_nuisance-true.yml
@@ -310,6 +310,7 @@ nuisance_corrections:
     - true
     space: template
 pipeline_setup:
+  freesurfer_dir: /ocean/projects/med220004p/trogers1/many_pipelines/freesurfer/outputs/ABCD_all_subjects
   Amazon-AWS:
     aws_output_bucket_credentials: null
     s3_encryption: true
@@ -360,7 +361,7 @@ pipeline_setup:
     random_seed: 77742777
   working_directory:
     path: /outputs/working
-    remove_working_dir: true
+    remove_working_dir: false
 post_processing:
   spatial_smoothing:
     fwhm:
@@ -456,7 +457,6 @@ registration_workflows:
         identity_matrix: $FSLDIR/etc/flirtsch/ident.mat
         interpolation: sinc
         ref_mask: null
-        ref_mask_res-2: null
         ref_resolution: 2mm
       using:
       - ANTS
@@ -494,8 +494,6 @@ registration_workflows:
           func_reg_input_volume: 0
         input:
         - fmriprep_reference
-        reg_with_skull: false
-      input: brain
       interpolation: trilinear
       run: true
       using: FSL
@@ -596,11 +594,6 @@ surface_analysis:
     run: false
     surface_parcellation_template: /cpac_templates/Schaefer2018_200Parcels_17Networks_order.dlabel.nii
 timeseries_extraction:
-  connectivity_matrix:
-    measure:
-    - Pearson
-    using:
-    - Nilearn
   realignment: ROI_to_func
   run: true
   tse_roi_paths:

--- a/configs/p143_base-rbc_perturb-fmriprep_step-functional-registration_conn-nilearn_nuisance-false.yml
+++ b/configs/p143_base-rbc_perturb-fmriprep_step-functional-registration_conn-nilearn_nuisance-false.yml
@@ -310,6 +310,7 @@ nuisance_corrections:
     - false
     space: template
 pipeline_setup:
+  freesurfer_dir: /ocean/projects/med220004p/trogers1/many_pipelines/freesurfer/outputs/ABCD_all_subjects
   Amazon-AWS:
     aws_output_bucket_credentials: null
     s3_encryption: true
@@ -360,7 +361,7 @@ pipeline_setup:
     random_seed: 77742777
   working_directory:
     path: /outputs/working
-    remove_working_dir: true
+    remove_working_dir: false
 post_processing:
   spatial_smoothing:
     fwhm:
@@ -456,7 +457,6 @@ registration_workflows:
         identity_matrix: $FSLDIR/etc/flirtsch/ident.mat
         interpolation: sinc
         ref_mask: null
-        ref_mask_res-2: null
         ref_resolution: 2mm
       using:
       - ANTS
@@ -494,8 +494,6 @@ registration_workflows:
           func_reg_input_volume: 0
         input:
         - fmriprep_reference
-        reg_with_skull: false
-      input: brain
       interpolation: trilinear
       run: true
       using: FSL
@@ -596,11 +594,6 @@ surface_analysis:
     run: false
     surface_parcellation_template: /cpac_templates/Schaefer2018_200Parcels_17Networks_order.dlabel.nii
 timeseries_extraction:
-  connectivity_matrix:
-    measure:
-    - Pearson
-    using:
-    - Nilearn
   realignment: ROI_to_func
   run: true
   tse_roi_paths:

--- a/configs/p144_base-fmriprep_perturb-abcd_step-structural-masking_conn-afni_nuisance-true.yml
+++ b/configs/p144_base-fmriprep_perturb-abcd_step-structural-masking_conn-afni_nuisance-true.yml
@@ -289,6 +289,7 @@ nuisance_corrections:
     - true
     space: template
 pipeline_setup:
+  freesurfer_dir: /ocean/projects/med220004p/trogers1/many_pipelines/freesurfer/outputs/ABCD_all_subjects
   Amazon-AWS:
     aws_output_bucket_credentials: null
     s3_encryption: true
@@ -339,7 +340,7 @@ pipeline_setup:
     random_seed: null
   working_directory:
     path: /outputs/working
-    remove_working_dir: true
+    remove_working_dir: false
 post_processing:
   spatial_smoothing:
     fwhm:
@@ -364,7 +365,7 @@ registration_workflows:
     T1w_brain_template_mask: /code/CPAC/resources/templates/tpl-MNI152NLin2009cAsym_res-01_desc-brain_mask.nii.gz
     T1w_template: /code/CPAC/resources/templates/mni_icbm152_t1_tal_nlin_asym_09c.nii
     overwrite_transform:
-      run: false
+      run: true
       using: FSL
     reg_with_skull: false
     registration:
@@ -428,12 +429,11 @@ registration_workflows:
       FSL-FNIRT:
         FNIRT_T1w_brain_template: null
         FNIRT_T1w_template: null
-        T1w_template_res-2: null
+        T1w_template_res-2: $FSLDIR/data/standard/MNI152_T1_2mm_brain.nii.gz
         fnirt_config: T1_2_MNI152_2mm
         identity_matrix: $FSLDIR/etc/flirtsch/ident.mat
         interpolation: sinc
         ref_mask: null
-        ref_mask_res-2: null
         ref_resolution: 2mm
       using:
       - ANTS
@@ -471,8 +471,6 @@ registration_workflows:
           func_reg_input_volume: 0
         input:
         - fmriprep_reference
-        reg_with_skull: false
-      input: brain
       interpolation: trilinear
       run: true
       using: FSL
@@ -549,7 +547,7 @@ segmentation:
     - FSL-FAST
 surface_analysis:
   abcd_prefreesurfer_prep:
-    run: false
+    run: true
   amplitude_low_frequency_fluctuation:
     run: false
   freesurfer:
@@ -573,11 +571,6 @@ surface_analysis:
     run: false
     surface_parcellation_template: /cpac_templates/Schaefer2018_200Parcels_17Networks_order.dlabel.nii
 timeseries_extraction:
-  connectivity_matrix:
-    measure:
-    - Pearson
-    using:
-    - AFNI
   realignment: ROI_to_func
   run: true
   tse_roi_paths:

--- a/configs/p145_base-fmriprep_perturb-abcd_step-structural-masking_conn-afni_nuisance-false.yml
+++ b/configs/p145_base-fmriprep_perturb-abcd_step-structural-masking_conn-afni_nuisance-false.yml
@@ -289,6 +289,7 @@ nuisance_corrections:
     - false
     space: template
 pipeline_setup:
+  freesurfer_dir: /ocean/projects/med220004p/trogers1/many_pipelines/freesurfer/outputs/ABCD_all_subjects
   Amazon-AWS:
     aws_output_bucket_credentials: null
     s3_encryption: true
@@ -339,7 +340,7 @@ pipeline_setup:
     random_seed: null
   working_directory:
     path: /outputs/working
-    remove_working_dir: true
+    remove_working_dir: false
 post_processing:
   spatial_smoothing:
     fwhm:
@@ -364,7 +365,7 @@ registration_workflows:
     T1w_brain_template_mask: /code/CPAC/resources/templates/tpl-MNI152NLin2009cAsym_res-01_desc-brain_mask.nii.gz
     T1w_template: /code/CPAC/resources/templates/mni_icbm152_t1_tal_nlin_asym_09c.nii
     overwrite_transform:
-      run: false
+      run: true
       using: FSL
     reg_with_skull: false
     registration:
@@ -428,12 +429,11 @@ registration_workflows:
       FSL-FNIRT:
         FNIRT_T1w_brain_template: null
         FNIRT_T1w_template: null
-        T1w_template_res-2: null
+        T1w_template_res-2: $FSLDIR/data/standard/MNI152_T1_2mm_brain.nii.gz
         fnirt_config: T1_2_MNI152_2mm
         identity_matrix: $FSLDIR/etc/flirtsch/ident.mat
         interpolation: sinc
         ref_mask: null
-        ref_mask_res-2: null
         ref_resolution: 2mm
       using:
       - ANTS
@@ -471,8 +471,6 @@ registration_workflows:
           func_reg_input_volume: 0
         input:
         - fmriprep_reference
-        reg_with_skull: false
-      input: brain
       interpolation: trilinear
       run: true
       using: FSL
@@ -549,7 +547,7 @@ segmentation:
     - FSL-FAST
 surface_analysis:
   abcd_prefreesurfer_prep:
-    run: false
+    run: true
   amplitude_low_frequency_fluctuation:
     run: false
   freesurfer:
@@ -573,11 +571,6 @@ surface_analysis:
     run: false
     surface_parcellation_template: /cpac_templates/Schaefer2018_200Parcels_17Networks_order.dlabel.nii
 timeseries_extraction:
-  connectivity_matrix:
-    measure:
-    - Pearson
-    using:
-    - AFNI
   realignment: ROI_to_func
   run: true
   tse_roi_paths:

--- a/configs/p146_base-fmriprep_perturb-abcd_step-structural-masking_conn-nilearn_nuisance-true.yml
+++ b/configs/p146_base-fmriprep_perturb-abcd_step-structural-masking_conn-nilearn_nuisance-true.yml
@@ -289,6 +289,7 @@ nuisance_corrections:
     - true
     space: template
 pipeline_setup:
+  freesurfer_dir: /ocean/projects/med220004p/trogers1/many_pipelines/freesurfer/outputs/ABCD_all_subjects
   Amazon-AWS:
     aws_output_bucket_credentials: null
     s3_encryption: true
@@ -339,7 +340,7 @@ pipeline_setup:
     random_seed: null
   working_directory:
     path: /outputs/working
-    remove_working_dir: true
+    remove_working_dir: false
 post_processing:
   spatial_smoothing:
     fwhm:
@@ -364,7 +365,7 @@ registration_workflows:
     T1w_brain_template_mask: /code/CPAC/resources/templates/tpl-MNI152NLin2009cAsym_res-01_desc-brain_mask.nii.gz
     T1w_template: /code/CPAC/resources/templates/mni_icbm152_t1_tal_nlin_asym_09c.nii
     overwrite_transform:
-      run: false
+      run: true
       using: FSL
     reg_with_skull: false
     registration:
@@ -428,12 +429,11 @@ registration_workflows:
       FSL-FNIRT:
         FNIRT_T1w_brain_template: null
         FNIRT_T1w_template: null
-        T1w_template_res-2: null
+        T1w_template_res-2: $FSLDIR/data/standard/MNI152_T1_2mm_brain.nii.gz
         fnirt_config: T1_2_MNI152_2mm
         identity_matrix: $FSLDIR/etc/flirtsch/ident.mat
         interpolation: sinc
         ref_mask: null
-        ref_mask_res-2: null
         ref_resolution: 2mm
       using:
       - ANTS
@@ -471,8 +471,6 @@ registration_workflows:
           func_reg_input_volume: 0
         input:
         - fmriprep_reference
-        reg_with_skull: false
-      input: brain
       interpolation: trilinear
       run: true
       using: FSL
@@ -549,7 +547,7 @@ segmentation:
     - FSL-FAST
 surface_analysis:
   abcd_prefreesurfer_prep:
-    run: false
+    run: true
   amplitude_low_frequency_fluctuation:
     run: false
   freesurfer:
@@ -573,11 +571,6 @@ surface_analysis:
     run: false
     surface_parcellation_template: /cpac_templates/Schaefer2018_200Parcels_17Networks_order.dlabel.nii
 timeseries_extraction:
-  connectivity_matrix:
-    measure:
-    - Pearson
-    using:
-    - Nilearn
   realignment: ROI_to_func
   run: true
   tse_roi_paths:

--- a/configs/p147_base-fmriprep_perturb-abcd_step-structural-masking_conn-nilearn_nuisance-false.yml
+++ b/configs/p147_base-fmriprep_perturb-abcd_step-structural-masking_conn-nilearn_nuisance-false.yml
@@ -289,6 +289,7 @@ nuisance_corrections:
     - false
     space: template
 pipeline_setup:
+  freesurfer_dir: /ocean/projects/med220004p/trogers1/many_pipelines/freesurfer/outputs/ABCD_all_subjects
   Amazon-AWS:
     aws_output_bucket_credentials: null
     s3_encryption: true
@@ -339,7 +340,7 @@ pipeline_setup:
     random_seed: null
   working_directory:
     path: /outputs/working
-    remove_working_dir: true
+    remove_working_dir: false
 post_processing:
   spatial_smoothing:
     fwhm:
@@ -364,7 +365,7 @@ registration_workflows:
     T1w_brain_template_mask: /code/CPAC/resources/templates/tpl-MNI152NLin2009cAsym_res-01_desc-brain_mask.nii.gz
     T1w_template: /code/CPAC/resources/templates/mni_icbm152_t1_tal_nlin_asym_09c.nii
     overwrite_transform:
-      run: false
+      run: true
       using: FSL
     reg_with_skull: false
     registration:
@@ -428,12 +429,11 @@ registration_workflows:
       FSL-FNIRT:
         FNIRT_T1w_brain_template: null
         FNIRT_T1w_template: null
-        T1w_template_res-2: null
+        T1w_template_res-2: $FSLDIR/data/standard/MNI152_T1_2mm_brain.nii.gz
         fnirt_config: T1_2_MNI152_2mm
         identity_matrix: $FSLDIR/etc/flirtsch/ident.mat
         interpolation: sinc
         ref_mask: null
-        ref_mask_res-2: null
         ref_resolution: 2mm
       using:
       - ANTS
@@ -471,8 +471,6 @@ registration_workflows:
           func_reg_input_volume: 0
         input:
         - fmriprep_reference
-        reg_with_skull: false
-      input: brain
       interpolation: trilinear
       run: true
       using: FSL
@@ -549,7 +547,7 @@ segmentation:
     - FSL-FAST
 surface_analysis:
   abcd_prefreesurfer_prep:
-    run: false
+    run: true
   amplitude_low_frequency_fluctuation:
     run: false
   freesurfer:
@@ -573,11 +571,6 @@ surface_analysis:
     run: false
     surface_parcellation_template: /cpac_templates/Schaefer2018_200Parcels_17Networks_order.dlabel.nii
 timeseries_extraction:
-  connectivity_matrix:
-    measure:
-    - Pearson
-    using:
-    - Nilearn
   realignment: ROI_to_func
   run: true
   tse_roi_paths:

--- a/configs/p148_base-fmriprep_perturb-abcd_step-structural-registration_conn-afni_nuisance-true.yml
+++ b/configs/p148_base-fmriprep_perturb-abcd_step-structural-registration_conn-afni_nuisance-true.yml
@@ -289,6 +289,7 @@ nuisance_corrections:
     - true
     space: template
 pipeline_setup:
+  freesurfer_dir: /ocean/projects/med220004p/trogers1/many_pipelines/freesurfer/outputs/ABCD_all_subjects
   Amazon-AWS:
     aws_output_bucket_credentials: null
     s3_encryption: true
@@ -339,7 +340,7 @@ pipeline_setup:
     random_seed: null
   working_directory:
     path: /outputs/working
-    remove_working_dir: true
+    remove_working_dir: false
 post_processing:
   spatial_smoothing:
     fwhm:
@@ -433,12 +434,10 @@ registration_workflows:
       FSL-FNIRT:
         FNIRT_T1w_brain_template: null
         FNIRT_T1w_template: null
-        T1w_template_res-2: /opt/dcan-tools/pipeline/global/templates/MNI152_T1_2mm.nii.gz
         fnirt_config: T1_2_MNI152_2mm
         identity_matrix: $FSLDIR/etc/flirtsch/ident.mat
         interpolation: sinc
         ref_mask: $FSLDIR/data/standard/MNI152_T1_${resolution_for_anat}_brain_mask_dil.nii.gz
-        ref_mask_res-2: /opt/dcan-tools/pipeline/global/templates/MNI152_T1_2mm_brain_mask_dil.nii.gz
         ref_resolution: 2mm
       using:
       - ANTS
@@ -476,8 +475,6 @@ registration_workflows:
           func_reg_input_volume: 0
         input:
         - fmriprep_reference
-        reg_with_skull: false
-      input: brain
       interpolation: trilinear
       run: true
       using: FSL
@@ -578,11 +575,6 @@ surface_analysis:
     run: false
     surface_parcellation_template: /cpac_templates/Schaefer2018_200Parcels_17Networks_order.dlabel.nii
 timeseries_extraction:
-  connectivity_matrix:
-    measure:
-    - Pearson
-    using:
-    - AFNI
   realignment: ROI_to_func
   run: true
   tse_roi_paths:

--- a/configs/p149_base-fmriprep_perturb-abcd_step-structural-registration_conn-afni_nuisance-false.yml
+++ b/configs/p149_base-fmriprep_perturb-abcd_step-structural-registration_conn-afni_nuisance-false.yml
@@ -289,6 +289,7 @@ nuisance_corrections:
     - false
     space: template
 pipeline_setup:
+  freesurfer_dir: /ocean/projects/med220004p/trogers1/many_pipelines/freesurfer/outputs/ABCD_all_subjects
   Amazon-AWS:
     aws_output_bucket_credentials: null
     s3_encryption: true
@@ -339,7 +340,7 @@ pipeline_setup:
     random_seed: null
   working_directory:
     path: /outputs/working
-    remove_working_dir: true
+    remove_working_dir: false
 post_processing:
   spatial_smoothing:
     fwhm:
@@ -433,12 +434,10 @@ registration_workflows:
       FSL-FNIRT:
         FNIRT_T1w_brain_template: null
         FNIRT_T1w_template: null
-        T1w_template_res-2: /opt/dcan-tools/pipeline/global/templates/MNI152_T1_2mm.nii.gz
         fnirt_config: T1_2_MNI152_2mm
         identity_matrix: $FSLDIR/etc/flirtsch/ident.mat
         interpolation: sinc
         ref_mask: $FSLDIR/data/standard/MNI152_T1_${resolution_for_anat}_brain_mask_dil.nii.gz
-        ref_mask_res-2: /opt/dcan-tools/pipeline/global/templates/MNI152_T1_2mm_brain_mask_dil.nii.gz
         ref_resolution: 2mm
       using:
       - ANTS
@@ -476,8 +475,6 @@ registration_workflows:
           func_reg_input_volume: 0
         input:
         - fmriprep_reference
-        reg_with_skull: false
-      input: brain
       interpolation: trilinear
       run: true
       using: FSL
@@ -578,11 +575,6 @@ surface_analysis:
     run: false
     surface_parcellation_template: /cpac_templates/Schaefer2018_200Parcels_17Networks_order.dlabel.nii
 timeseries_extraction:
-  connectivity_matrix:
-    measure:
-    - Pearson
-    using:
-    - AFNI
   realignment: ROI_to_func
   run: true
   tse_roi_paths:

--- a/configs/p150_base-fmriprep_perturb-abcd_step-structural-registration_conn-nilearn_nuisance-true.yml
+++ b/configs/p150_base-fmriprep_perturb-abcd_step-structural-registration_conn-nilearn_nuisance-true.yml
@@ -289,6 +289,7 @@ nuisance_corrections:
     - true
     space: template
 pipeline_setup:
+  freesurfer_dir: /ocean/projects/med220004p/trogers1/many_pipelines/freesurfer/outputs/ABCD_all_subjects
   Amazon-AWS:
     aws_output_bucket_credentials: null
     s3_encryption: true
@@ -339,7 +340,7 @@ pipeline_setup:
     random_seed: null
   working_directory:
     path: /outputs/working
-    remove_working_dir: true
+    remove_working_dir: false
 post_processing:
   spatial_smoothing:
     fwhm:
@@ -433,12 +434,10 @@ registration_workflows:
       FSL-FNIRT:
         FNIRT_T1w_brain_template: null
         FNIRT_T1w_template: null
-        T1w_template_res-2: /opt/dcan-tools/pipeline/global/templates/MNI152_T1_2mm.nii.gz
         fnirt_config: T1_2_MNI152_2mm
         identity_matrix: $FSLDIR/etc/flirtsch/ident.mat
         interpolation: sinc
         ref_mask: $FSLDIR/data/standard/MNI152_T1_${resolution_for_anat}_brain_mask_dil.nii.gz
-        ref_mask_res-2: /opt/dcan-tools/pipeline/global/templates/MNI152_T1_2mm_brain_mask_dil.nii.gz
         ref_resolution: 2mm
       using:
       - ANTS
@@ -476,8 +475,6 @@ registration_workflows:
           func_reg_input_volume: 0
         input:
         - fmriprep_reference
-        reg_with_skull: false
-      input: brain
       interpolation: trilinear
       run: true
       using: FSL
@@ -578,11 +575,6 @@ surface_analysis:
     run: false
     surface_parcellation_template: /cpac_templates/Schaefer2018_200Parcels_17Networks_order.dlabel.nii
 timeseries_extraction:
-  connectivity_matrix:
-    measure:
-    - Pearson
-    using:
-    - Nilearn
   realignment: ROI_to_func
   run: true
   tse_roi_paths:

--- a/configs/p151_base-fmriprep_perturb-abcd_step-structural-registration_conn-nilearn_nuisance-false.yml
+++ b/configs/p151_base-fmriprep_perturb-abcd_step-structural-registration_conn-nilearn_nuisance-false.yml
@@ -289,6 +289,7 @@ nuisance_corrections:
     - false
     space: template
 pipeline_setup:
+  freesurfer_dir: /ocean/projects/med220004p/trogers1/many_pipelines/freesurfer/outputs/ABCD_all_subjects
   Amazon-AWS:
     aws_output_bucket_credentials: null
     s3_encryption: true
@@ -339,7 +340,7 @@ pipeline_setup:
     random_seed: null
   working_directory:
     path: /outputs/working
-    remove_working_dir: true
+    remove_working_dir: false
 post_processing:
   spatial_smoothing:
     fwhm:
@@ -433,12 +434,10 @@ registration_workflows:
       FSL-FNIRT:
         FNIRT_T1w_brain_template: null
         FNIRT_T1w_template: null
-        T1w_template_res-2: /opt/dcan-tools/pipeline/global/templates/MNI152_T1_2mm.nii.gz
         fnirt_config: T1_2_MNI152_2mm
         identity_matrix: $FSLDIR/etc/flirtsch/ident.mat
         interpolation: sinc
         ref_mask: $FSLDIR/data/standard/MNI152_T1_${resolution_for_anat}_brain_mask_dil.nii.gz
-        ref_mask_res-2: /opt/dcan-tools/pipeline/global/templates/MNI152_T1_2mm_brain_mask_dil.nii.gz
         ref_resolution: 2mm
       using:
       - ANTS
@@ -476,8 +475,6 @@ registration_workflows:
           func_reg_input_volume: 0
         input:
         - fmriprep_reference
-        reg_with_skull: false
-      input: brain
       interpolation: trilinear
       run: true
       using: FSL
@@ -578,11 +575,6 @@ surface_analysis:
     run: false
     surface_parcellation_template: /cpac_templates/Schaefer2018_200Parcels_17Networks_order.dlabel.nii
 timeseries_extraction:
-  connectivity_matrix:
-    measure:
-    - Pearson
-    using:
-    - Nilearn
   realignment: ROI_to_func
   run: true
   tse_roi_paths:

--- a/configs/p152_base-fmriprep_perturb-abcd_step-functional-masking_conn-afni_nuisance-true.yml
+++ b/configs/p152_base-fmriprep_perturb-abcd_step-functional-masking_conn-afni_nuisance-true.yml
@@ -149,7 +149,7 @@ functional_preproc:
     apply_func_mask_in_native_space: false
     run: true
     using:
-    - Anatomical_Resampled
+    - CCS_Anatomical_Refined
   generate_func_mean:
     run: true
   motion_estimates_and_correction:
@@ -289,6 +289,7 @@ nuisance_corrections:
     - true
     space: template
 pipeline_setup:
+  freesurfer_dir: /ocean/projects/med220004p/trogers1/many_pipelines/freesurfer/outputs/ABCD_all_subjects
   Amazon-AWS:
     aws_output_bucket_credentials: null
     s3_encryption: true
@@ -339,7 +340,7 @@ pipeline_setup:
     random_seed: null
   working_directory:
     path: /outputs/working
-    remove_working_dir: true
+    remove_working_dir: false
 post_processing:
   spatial_smoothing:
     fwhm:
@@ -364,7 +365,7 @@ registration_workflows:
     T1w_brain_template_mask: /opt/dcan-tools/pipeline/global/templates/MNI152_T1_${resolution_for_anat}_brain_mask.nii.gz
     T1w_template: /code/CPAC/resources/templates/mni_icbm152_t1_tal_nlin_asym_09c.nii
     overwrite_transform:
-      run: false
+      run: true
       using: FSL
     reg_with_skull: false
     registration:
@@ -433,7 +434,6 @@ registration_workflows:
         identity_matrix: $FSLDIR/etc/flirtsch/ident.mat
         interpolation: sinc
         ref_mask: null
-        ref_mask_res-2: null
         ref_resolution: 2mm
       using:
       - ANTS
@@ -471,8 +471,6 @@ registration_workflows:
           func_reg_input_volume: 0
         input:
         - fmriprep_reference
-        reg_with_skull: false
-      input: brain
       interpolation: trilinear
       run: true
       using: FSL
@@ -573,11 +571,6 @@ surface_analysis:
     run: false
     surface_parcellation_template: /cpac_templates/Schaefer2018_200Parcels_17Networks_order.dlabel.nii
 timeseries_extraction:
-  connectivity_matrix:
-    measure:
-    - Pearson
-    using:
-    - AFNI
   realignment: ROI_to_func
   run: true
   tse_roi_paths:

--- a/configs/p153_base-fmriprep_perturb-abcd_step-functional-masking_conn-afni_nuisance-false.yml
+++ b/configs/p153_base-fmriprep_perturb-abcd_step-functional-masking_conn-afni_nuisance-false.yml
@@ -149,7 +149,7 @@ functional_preproc:
     apply_func_mask_in_native_space: false
     run: true
     using:
-    - Anatomical_Resampled
+    - CCS_Anatomical_Refined
   generate_func_mean:
     run: true
   motion_estimates_and_correction:
@@ -289,6 +289,7 @@ nuisance_corrections:
     - false
     space: template
 pipeline_setup:
+  freesurfer_dir: /ocean/projects/med220004p/trogers1/many_pipelines/freesurfer/outputs/ABCD_all_subjects
   Amazon-AWS:
     aws_output_bucket_credentials: null
     s3_encryption: true
@@ -339,7 +340,7 @@ pipeline_setup:
     random_seed: null
   working_directory:
     path: /outputs/working
-    remove_working_dir: true
+    remove_working_dir: false
 post_processing:
   spatial_smoothing:
     fwhm:
@@ -364,7 +365,7 @@ registration_workflows:
     T1w_brain_template_mask: /opt/dcan-tools/pipeline/global/templates/MNI152_T1_${resolution_for_anat}_brain_mask.nii.gz
     T1w_template: /code/CPAC/resources/templates/mni_icbm152_t1_tal_nlin_asym_09c.nii
     overwrite_transform:
-      run: false
+      run: true
       using: FSL
     reg_with_skull: false
     registration:
@@ -433,7 +434,6 @@ registration_workflows:
         identity_matrix: $FSLDIR/etc/flirtsch/ident.mat
         interpolation: sinc
         ref_mask: null
-        ref_mask_res-2: null
         ref_resolution: 2mm
       using:
       - ANTS
@@ -471,8 +471,6 @@ registration_workflows:
           func_reg_input_volume: 0
         input:
         - fmriprep_reference
-        reg_with_skull: false
-      input: brain
       interpolation: trilinear
       run: true
       using: FSL
@@ -573,11 +571,6 @@ surface_analysis:
     run: false
     surface_parcellation_template: /cpac_templates/Schaefer2018_200Parcels_17Networks_order.dlabel.nii
 timeseries_extraction:
-  connectivity_matrix:
-    measure:
-    - Pearson
-    using:
-    - AFNI
   realignment: ROI_to_func
   run: true
   tse_roi_paths:

--- a/configs/p154_base-fmriprep_perturb-abcd_step-functional-masking_conn-nilearn_nuisance-true.yml
+++ b/configs/p154_base-fmriprep_perturb-abcd_step-functional-masking_conn-nilearn_nuisance-true.yml
@@ -13,7 +13,7 @@ amplitude_low_frequency_fluctuation:
   - 0.01
   lowpass_cutoff:
   - 0.1
-  run: false
+  run: true
   target_space:
   - Native
 anatomical_preproc:
@@ -149,7 +149,7 @@ functional_preproc:
     apply_func_mask_in_native_space: false
     run: true
     using:
-    - Anatomical_Resampled
+    - CCS_Anatomical_Refined
   generate_func_mean:
     run: true
   motion_estimates_and_correction:
@@ -289,6 +289,7 @@ nuisance_corrections:
     - true
     space: template
 pipeline_setup:
+  freesurfer_dir: /ocean/projects/med220004p/trogers1/many_pipelines/freesurfer/outputs/ABCD_all_subjects
   Amazon-AWS:
     aws_output_bucket_credentials: null
     s3_encryption: true
@@ -339,7 +340,7 @@ pipeline_setup:
     random_seed: null
   working_directory:
     path: /outputs/working
-    remove_working_dir: true
+    remove_working_dir: false
 post_processing:
   spatial_smoothing:
     fwhm:
@@ -364,7 +365,7 @@ registration_workflows:
     T1w_brain_template_mask: /opt/dcan-tools/pipeline/global/templates/MNI152_T1_${resolution_for_anat}_brain_mask.nii.gz
     T1w_template: /code/CPAC/resources/templates/mni_icbm152_t1_tal_nlin_asym_09c.nii
     overwrite_transform:
-      run: false
+      run: true
       using: FSL
     reg_with_skull: false
     registration:
@@ -433,7 +434,6 @@ registration_workflows:
         identity_matrix: $FSLDIR/etc/flirtsch/ident.mat
         interpolation: sinc
         ref_mask: null
-        ref_mask_res-2: null
         ref_resolution: 2mm
       using:
       - ANTS
@@ -471,8 +471,6 @@ registration_workflows:
           func_reg_input_volume: 0
         input:
         - fmriprep_reference
-        reg_with_skull: false
-      input: brain
       interpolation: trilinear
       run: true
       using: FSL
@@ -573,11 +571,6 @@ surface_analysis:
     run: false
     surface_parcellation_template: /cpac_templates/Schaefer2018_200Parcels_17Networks_order.dlabel.nii
 timeseries_extraction:
-  connectivity_matrix:
-    measure:
-    - Pearson
-    using:
-    - Nilearn
   realignment: ROI_to_func
   run: true
   tse_roi_paths:

--- a/configs/p155_base-fmriprep_perturb-abcd_step-functional-masking_conn-nilearn_nuisance-false.yml
+++ b/configs/p155_base-fmriprep_perturb-abcd_step-functional-masking_conn-nilearn_nuisance-false.yml
@@ -149,7 +149,7 @@ functional_preproc:
     apply_func_mask_in_native_space: false
     run: true
     using:
-    - Anatomical_Resampled
+    - CCS_Anatomical_Refined
   generate_func_mean:
     run: true
   motion_estimates_and_correction:
@@ -289,6 +289,7 @@ nuisance_corrections:
     - false
     space: template
 pipeline_setup:
+  freesurfer_dir: /ocean/projects/med220004p/trogers1/many_pipelines/freesurfer/outputs/ABCD_all_subjects
   Amazon-AWS:
     aws_output_bucket_credentials: null
     s3_encryption: true
@@ -339,7 +340,7 @@ pipeline_setup:
     random_seed: null
   working_directory:
     path: /outputs/working
-    remove_working_dir: true
+    remove_working_dir: false
 post_processing:
   spatial_smoothing:
     fwhm:
@@ -364,7 +365,7 @@ registration_workflows:
     T1w_brain_template_mask: /opt/dcan-tools/pipeline/global/templates/MNI152_T1_${resolution_for_anat}_brain_mask.nii.gz
     T1w_template: /code/CPAC/resources/templates/mni_icbm152_t1_tal_nlin_asym_09c.nii
     overwrite_transform:
-      run: false
+      run: true
       using: FSL
     reg_with_skull: false
     registration:
@@ -433,7 +434,6 @@ registration_workflows:
         identity_matrix: $FSLDIR/etc/flirtsch/ident.mat
         interpolation: sinc
         ref_mask: null
-        ref_mask_res-2: null
         ref_resolution: 2mm
       using:
       - ANTS
@@ -471,8 +471,6 @@ registration_workflows:
           func_reg_input_volume: 0
         input:
         - fmriprep_reference
-        reg_with_skull: false
-      input: brain
       interpolation: trilinear
       run: true
       using: FSL
@@ -573,11 +571,6 @@ surface_analysis:
     run: false
     surface_parcellation_template: /cpac_templates/Schaefer2018_200Parcels_17Networks_order.dlabel.nii
 timeseries_extraction:
-  connectivity_matrix:
-    measure:
-    - Pearson
-    using:
-    - Nilearn
   realignment: ROI_to_func
   run: true
   tse_roi_paths:

--- a/configs/p156_base-fmriprep_perturb-abcd_step-functional-registration_conn-afni_nuisance-true.yml
+++ b/configs/p156_base-fmriprep_perturb-abcd_step-functional-registration_conn-afni_nuisance-true.yml
@@ -289,6 +289,7 @@ nuisance_corrections:
     - true
     space: template
 pipeline_setup:
+  freesurfer_dir: /ocean/projects/med220004p/trogers1/many_pipelines/freesurfer/outputs/ABCD_all_subjects
   Amazon-AWS:
     aws_output_bucket_credentials: null
     s3_encryption: true
@@ -339,7 +340,7 @@ pipeline_setup:
     random_seed: null
   working_directory:
     path: /outputs/working
-    remove_working_dir: true
+    remove_working_dir: false
 post_processing:
   spatial_smoothing:
     fwhm:
@@ -433,7 +434,6 @@ registration_workflows:
         identity_matrix: $FSLDIR/etc/flirtsch/ident.mat
         interpolation: sinc
         ref_mask: null
-        ref_mask_res-2: null
         ref_resolution: 2mm
       using:
       - ANTS
@@ -471,8 +471,6 @@ registration_workflows:
           func_reg_input_volume: 0
         input:
         - Selected_Functional_Volume
-        reg_with_skull: true
-      input: brain
       interpolation: spline
       run: true
       using: FSL
@@ -573,11 +571,6 @@ surface_analysis:
     run: false
     surface_parcellation_template: /cpac_templates/Schaefer2018_200Parcels_17Networks_order.dlabel.nii
 timeseries_extraction:
-  connectivity_matrix:
-    measure:
-    - Pearson
-    using:
-    - AFNI
   realignment: ROI_to_func
   run: true
   tse_roi_paths:

--- a/configs/p157_base-fmriprep_perturb-abcd_step-functional-registration_conn-afni_nuisance-false.yml
+++ b/configs/p157_base-fmriprep_perturb-abcd_step-functional-registration_conn-afni_nuisance-false.yml
@@ -289,6 +289,7 @@ nuisance_corrections:
     - false
     space: template
 pipeline_setup:
+  freesurfer_dir: /ocean/projects/med220004p/trogers1/many_pipelines/freesurfer/outputs/ABCD_all_subjects
   Amazon-AWS:
     aws_output_bucket_credentials: null
     s3_encryption: true
@@ -339,7 +340,7 @@ pipeline_setup:
     random_seed: null
   working_directory:
     path: /outputs/working
-    remove_working_dir: true
+    remove_working_dir: false
 post_processing:
   spatial_smoothing:
     fwhm:
@@ -433,7 +434,6 @@ registration_workflows:
         identity_matrix: $FSLDIR/etc/flirtsch/ident.mat
         interpolation: sinc
         ref_mask: null
-        ref_mask_res-2: null
         ref_resolution: 2mm
       using:
       - ANTS
@@ -471,8 +471,6 @@ registration_workflows:
           func_reg_input_volume: 0
         input:
         - Selected_Functional_Volume
-        reg_with_skull: true
-      input: brain
       interpolation: spline
       run: true
       using: FSL
@@ -573,11 +571,6 @@ surface_analysis:
     run: false
     surface_parcellation_template: /cpac_templates/Schaefer2018_200Parcels_17Networks_order.dlabel.nii
 timeseries_extraction:
-  connectivity_matrix:
-    measure:
-    - Pearson
-    using:
-    - AFNI
   realignment: ROI_to_func
   run: true
   tse_roi_paths:

--- a/configs/p158_base-fmriprep_perturb-abcd_step-functional-registration_conn-nilearn_nuisance-true.yml
+++ b/configs/p158_base-fmriprep_perturb-abcd_step-functional-registration_conn-nilearn_nuisance-true.yml
@@ -289,6 +289,7 @@ nuisance_corrections:
     - true
     space: template
 pipeline_setup:
+  freesurfer_dir: /ocean/projects/med220004p/trogers1/many_pipelines/freesurfer/outputs/ABCD_all_subjects
   Amazon-AWS:
     aws_output_bucket_credentials: null
     s3_encryption: true
@@ -339,7 +340,7 @@ pipeline_setup:
     random_seed: null
   working_directory:
     path: /outputs/working
-    remove_working_dir: true
+    remove_working_dir: false
 post_processing:
   spatial_smoothing:
     fwhm:
@@ -433,7 +434,6 @@ registration_workflows:
         identity_matrix: $FSLDIR/etc/flirtsch/ident.mat
         interpolation: sinc
         ref_mask: null
-        ref_mask_res-2: null
         ref_resolution: 2mm
       using:
       - ANTS
@@ -471,8 +471,6 @@ registration_workflows:
           func_reg_input_volume: 0
         input:
         - Selected_Functional_Volume
-        reg_with_skull: true
-      input: brain
       interpolation: spline
       run: true
       using: FSL
@@ -573,11 +571,6 @@ surface_analysis:
     run: false
     surface_parcellation_template: /cpac_templates/Schaefer2018_200Parcels_17Networks_order.dlabel.nii
 timeseries_extraction:
-  connectivity_matrix:
-    measure:
-    - Pearson
-    using:
-    - Nilearn
   realignment: ROI_to_func
   run: true
   tse_roi_paths:

--- a/configs/p159_base-fmriprep_perturb-abcd_step-functional-registration_conn-nilearn_nuisance-false.yml
+++ b/configs/p159_base-fmriprep_perturb-abcd_step-functional-registration_conn-nilearn_nuisance-false.yml
@@ -289,6 +289,7 @@ nuisance_corrections:
     - false
     space: template
 pipeline_setup:
+  freesurfer_dir: /ocean/projects/med220004p/trogers1/many_pipelines/freesurfer/outputs/ABCD_all_subjects
   Amazon-AWS:
     aws_output_bucket_credentials: null
     s3_encryption: true
@@ -339,7 +340,7 @@ pipeline_setup:
     random_seed: null
   working_directory:
     path: /outputs/working
-    remove_working_dir: true
+    remove_working_dir: false
 post_processing:
   spatial_smoothing:
     fwhm:
@@ -433,7 +434,6 @@ registration_workflows:
         identity_matrix: $FSLDIR/etc/flirtsch/ident.mat
         interpolation: sinc
         ref_mask: null
-        ref_mask_res-2: null
         ref_resolution: 2mm
       using:
       - ANTS
@@ -471,8 +471,6 @@ registration_workflows:
           func_reg_input_volume: 0
         input:
         - Selected_Functional_Volume
-        reg_with_skull: true
-      input: brain
       interpolation: spline
       run: true
       using: FSL
@@ -573,11 +571,6 @@ surface_analysis:
     run: false
     surface_parcellation_template: /cpac_templates/Schaefer2018_200Parcels_17Networks_order.dlabel.nii
 timeseries_extraction:
-  connectivity_matrix:
-    measure:
-    - Pearson
-    using:
-    - Nilearn
   realignment: ROI_to_func
   run: true
   tse_roi_paths:

--- a/configs/p160_base-fmriprep_perturb-ccs_step-structural-masking_conn-afni_nuisance-true.yml
+++ b/configs/p160_base-fmriprep_perturb-ccs_step-structural-masking_conn-afni_nuisance-true.yml
@@ -291,6 +291,7 @@ nuisance_corrections:
     - true
     space: template
 pipeline_setup:
+  freesurfer_dir: /ocean/projects/med220004p/trogers1/many_pipelines/freesurfer/outputs/ABCD_all_subjects
   Amazon-AWS:
     aws_output_bucket_credentials: null
     s3_encryption: true
@@ -341,7 +342,7 @@ pipeline_setup:
     random_seed: null
   working_directory:
     path: /outputs/working
-    remove_working_dir: true
+    remove_working_dir: false
 post_processing:
   spatial_smoothing:
     fwhm:
@@ -435,7 +436,6 @@ registration_workflows:
         identity_matrix: $FSLDIR/etc/flirtsch/ident.mat
         interpolation: sinc
         ref_mask: null
-        ref_mask_res-2: null
         ref_resolution: 2mm
       using:
       - ANTS
@@ -473,8 +473,6 @@ registration_workflows:
           func_reg_input_volume: 0
         input:
         - fmriprep_reference
-        reg_with_skull: false
-      input: brain
       interpolation: trilinear
       run: true
       using: FSL
@@ -575,11 +573,6 @@ surface_analysis:
     run: false
     surface_parcellation_template: /cpac_templates/Schaefer2018_200Parcels_17Networks_order.dlabel.nii
 timeseries_extraction:
-  connectivity_matrix:
-    measure:
-    - Pearson
-    using:
-    - AFNI
   realignment: ROI_to_func
   run: true
   tse_roi_paths:

--- a/configs/p161_base-fmriprep_perturb-ccs_step-structural-masking_conn-afni_nuisance-false.yml
+++ b/configs/p161_base-fmriprep_perturb-ccs_step-structural-masking_conn-afni_nuisance-false.yml
@@ -291,6 +291,7 @@ nuisance_corrections:
     - false
     space: template
 pipeline_setup:
+  freesurfer_dir: /ocean/projects/med220004p/trogers1/many_pipelines/freesurfer/outputs/ABCD_all_subjects
   Amazon-AWS:
     aws_output_bucket_credentials: null
     s3_encryption: true
@@ -341,7 +342,7 @@ pipeline_setup:
     random_seed: null
   working_directory:
     path: /outputs/working
-    remove_working_dir: true
+    remove_working_dir: false
 post_processing:
   spatial_smoothing:
     fwhm:
@@ -435,7 +436,6 @@ registration_workflows:
         identity_matrix: $FSLDIR/etc/flirtsch/ident.mat
         interpolation: sinc
         ref_mask: null
-        ref_mask_res-2: null
         ref_resolution: 2mm
       using:
       - ANTS
@@ -473,8 +473,6 @@ registration_workflows:
           func_reg_input_volume: 0
         input:
         - fmriprep_reference
-        reg_with_skull: false
-      input: brain
       interpolation: trilinear
       run: true
       using: FSL
@@ -575,11 +573,6 @@ surface_analysis:
     run: false
     surface_parcellation_template: /cpac_templates/Schaefer2018_200Parcels_17Networks_order.dlabel.nii
 timeseries_extraction:
-  connectivity_matrix:
-    measure:
-    - Pearson
-    using:
-    - AFNI
   realignment: ROI_to_func
   run: true
   tse_roi_paths:

--- a/configs/p162_base-fmriprep_perturb-ccs_step-structural-masking_conn-nilearn_nuisance-true.yml
+++ b/configs/p162_base-fmriprep_perturb-ccs_step-structural-masking_conn-nilearn_nuisance-true.yml
@@ -291,6 +291,7 @@ nuisance_corrections:
     - true
     space: template
 pipeline_setup:
+  freesurfer_dir: /ocean/projects/med220004p/trogers1/many_pipelines/freesurfer/outputs/ABCD_all_subjects
   Amazon-AWS:
     aws_output_bucket_credentials: null
     s3_encryption: true
@@ -341,7 +342,7 @@ pipeline_setup:
     random_seed: null
   working_directory:
     path: /outputs/working
-    remove_working_dir: true
+    remove_working_dir: false
 post_processing:
   spatial_smoothing:
     fwhm:
@@ -435,7 +436,6 @@ registration_workflows:
         identity_matrix: $FSLDIR/etc/flirtsch/ident.mat
         interpolation: sinc
         ref_mask: null
-        ref_mask_res-2: null
         ref_resolution: 2mm
       using:
       - ANTS
@@ -473,8 +473,6 @@ registration_workflows:
           func_reg_input_volume: 0
         input:
         - fmriprep_reference
-        reg_with_skull: false
-      input: brain
       interpolation: trilinear
       run: true
       using: FSL
@@ -575,11 +573,6 @@ surface_analysis:
     run: false
     surface_parcellation_template: /cpac_templates/Schaefer2018_200Parcels_17Networks_order.dlabel.nii
 timeseries_extraction:
-  connectivity_matrix:
-    measure:
-    - Pearson
-    using:
-    - Nilearn
   realignment: ROI_to_func
   run: true
   tse_roi_paths:

--- a/configs/p163_base-fmriprep_perturb-ccs_step-structural-masking_conn-nilearn_nuisance-false.yml
+++ b/configs/p163_base-fmriprep_perturb-ccs_step-structural-masking_conn-nilearn_nuisance-false.yml
@@ -291,6 +291,7 @@ nuisance_corrections:
     - false
     space: template
 pipeline_setup:
+  freesurfer_dir: /ocean/projects/med220004p/trogers1/many_pipelines/freesurfer/outputs/ABCD_all_subjects
   Amazon-AWS:
     aws_output_bucket_credentials: null
     s3_encryption: true
@@ -341,7 +342,7 @@ pipeline_setup:
     random_seed: null
   working_directory:
     path: /outputs/working
-    remove_working_dir: true
+    remove_working_dir: false
 post_processing:
   spatial_smoothing:
     fwhm:
@@ -435,7 +436,6 @@ registration_workflows:
         identity_matrix: $FSLDIR/etc/flirtsch/ident.mat
         interpolation: sinc
         ref_mask: null
-        ref_mask_res-2: null
         ref_resolution: 2mm
       using:
       - ANTS
@@ -473,8 +473,6 @@ registration_workflows:
           func_reg_input_volume: 0
         input:
         - fmriprep_reference
-        reg_with_skull: false
-      input: brain
       interpolation: trilinear
       run: true
       using: FSL
@@ -575,11 +573,6 @@ surface_analysis:
     run: false
     surface_parcellation_template: /cpac_templates/Schaefer2018_200Parcels_17Networks_order.dlabel.nii
 timeseries_extraction:
-  connectivity_matrix:
-    measure:
-    - Pearson
-    using:
-    - Nilearn
   realignment: ROI_to_func
   run: true
   tse_roi_paths:

--- a/configs/p164_base-fmriprep_perturb-ccs_step-structural-registration_conn-afni_nuisance-true.yml
+++ b/configs/p164_base-fmriprep_perturb-ccs_step-structural-registration_conn-afni_nuisance-true.yml
@@ -289,6 +289,7 @@ nuisance_corrections:
     - true
     space: template
 pipeline_setup:
+  freesurfer_dir: /ocean/projects/med220004p/trogers1/many_pipelines/freesurfer/outputs/ABCD_all_subjects
   Amazon-AWS:
     aws_output_bucket_credentials: null
     s3_encryption: true
@@ -339,7 +340,7 @@ pipeline_setup:
     random_seed: null
   working_directory:
     path: /outputs/working
-    remove_working_dir: true
+    remove_working_dir: false
 post_processing:
   spatial_smoothing:
     fwhm:
@@ -365,7 +366,6 @@ registration_workflows:
     T1w_template: $FSLDIR/data/standard/MNI152_T1_${resolution_for_anat}.nii.gz
     overwrite_transform:
       run: false
-      using: FSL
     reg_with_skull: false
     registration:
       ANTs:
@@ -433,10 +433,9 @@ registration_workflows:
         identity_matrix: $FSLDIR/etc/flirtsch/ident.mat
         interpolation: trilinear
         ref_mask: $FSLDIR/data/standard/MNI152_T1_${resolution_for_anat}_brain_mask_dil.nii.gz
-        ref_mask_res-2: $FSLDIR/data/standard/MNI152_T1_2mm_brain_mask_dil.nii.gz
         ref_resolution: 2mm
       using:
-      - FSL
+      - ANTS
     resolution_for_anat: 2mm
     run: true
   functional_registration:
@@ -471,8 +470,6 @@ registration_workflows:
           func_reg_input_volume: 0
         input:
         - fmriprep_reference
-        reg_with_skull: false
-      input: brain
       interpolation: trilinear
       run: true
       using: FSL
@@ -573,11 +570,6 @@ surface_analysis:
     run: false
     surface_parcellation_template: /cpac_templates/Schaefer2018_200Parcels_17Networks_order.dlabel.nii
 timeseries_extraction:
-  connectivity_matrix:
-    measure:
-    - Pearson
-    using:
-    - AFNI
   realignment: ROI_to_func
   run: true
   tse_roi_paths:

--- a/configs/p165_base-fmriprep_perturb-ccs_step-structural-registration_conn-afni_nuisance-false.yml
+++ b/configs/p165_base-fmriprep_perturb-ccs_step-structural-registration_conn-afni_nuisance-false.yml
@@ -289,6 +289,7 @@ nuisance_corrections:
     - false
     space: template
 pipeline_setup:
+  freesurfer_dir: /ocean/projects/med220004p/trogers1/many_pipelines/freesurfer/outputs/ABCD_all_subjects
   Amazon-AWS:
     aws_output_bucket_credentials: null
     s3_encryption: true
@@ -339,7 +340,7 @@ pipeline_setup:
     random_seed: null
   working_directory:
     path: /outputs/working
-    remove_working_dir: true
+    remove_working_dir: false
 post_processing:
   spatial_smoothing:
     fwhm:
@@ -365,7 +366,6 @@ registration_workflows:
     T1w_template: $FSLDIR/data/standard/MNI152_T1_${resolution_for_anat}.nii.gz
     overwrite_transform:
       run: false
-      using: FSL
     reg_with_skull: false
     registration:
       ANTs:
@@ -433,10 +433,9 @@ registration_workflows:
         identity_matrix: $FSLDIR/etc/flirtsch/ident.mat
         interpolation: trilinear
         ref_mask: $FSLDIR/data/standard/MNI152_T1_${resolution_for_anat}_brain_mask_dil.nii.gz
-        ref_mask_res-2: $FSLDIR/data/standard/MNI152_T1_2mm_brain_mask_dil.nii.gz
         ref_resolution: 2mm
       using:
-      - FSL
+      - ANTS
     resolution_for_anat: 2mm
     run: true
   functional_registration:
@@ -471,8 +470,6 @@ registration_workflows:
           func_reg_input_volume: 0
         input:
         - fmriprep_reference
-        reg_with_skull: false
-      input: brain
       interpolation: trilinear
       run: true
       using: FSL
@@ -573,11 +570,6 @@ surface_analysis:
     run: false
     surface_parcellation_template: /cpac_templates/Schaefer2018_200Parcels_17Networks_order.dlabel.nii
 timeseries_extraction:
-  connectivity_matrix:
-    measure:
-    - Pearson
-    using:
-    - AFNI
   realignment: ROI_to_func
   run: true
   tse_roi_paths:

--- a/configs/p166_base-fmriprep_perturb-ccs_step-structural-registration_conn-nilearn_nuisance-true.yml
+++ b/configs/p166_base-fmriprep_perturb-ccs_step-structural-registration_conn-nilearn_nuisance-true.yml
@@ -289,6 +289,7 @@ nuisance_corrections:
     - true
     space: template
 pipeline_setup:
+  freesurfer_dir: /ocean/projects/med220004p/trogers1/many_pipelines/freesurfer/outputs/ABCD_all_subjects
   Amazon-AWS:
     aws_output_bucket_credentials: null
     s3_encryption: true
@@ -339,7 +340,7 @@ pipeline_setup:
     random_seed: null
   working_directory:
     path: /outputs/working
-    remove_working_dir: true
+    remove_working_dir: false
 post_processing:
   spatial_smoothing:
     fwhm:
@@ -365,7 +366,6 @@ registration_workflows:
     T1w_template: $FSLDIR/data/standard/MNI152_T1_${resolution_for_anat}.nii.gz
     overwrite_transform:
       run: false
-      using: FSL
     reg_with_skull: false
     registration:
       ANTs:
@@ -433,10 +433,9 @@ registration_workflows:
         identity_matrix: $FSLDIR/etc/flirtsch/ident.mat
         interpolation: trilinear
         ref_mask: $FSLDIR/data/standard/MNI152_T1_${resolution_for_anat}_brain_mask_dil.nii.gz
-        ref_mask_res-2: $FSLDIR/data/standard/MNI152_T1_2mm_brain_mask_dil.nii.gz
         ref_resolution: 2mm
       using:
-      - FSL
+      - ANTS
     resolution_for_anat: 2mm
     run: true
   functional_registration:
@@ -471,8 +470,6 @@ registration_workflows:
           func_reg_input_volume: 0
         input:
         - fmriprep_reference
-        reg_with_skull: false
-      input: brain
       interpolation: trilinear
       run: true
       using: FSL
@@ -573,11 +570,6 @@ surface_analysis:
     run: false
     surface_parcellation_template: /cpac_templates/Schaefer2018_200Parcels_17Networks_order.dlabel.nii
 timeseries_extraction:
-  connectivity_matrix:
-    measure:
-    - Pearson
-    using:
-    - Nilearn
   realignment: ROI_to_func
   run: true
   tse_roi_paths:

--- a/configs/p167_base-fmriprep_perturb-ccs_step-structural-registration_conn-nilearn_nuisance-false.yml
+++ b/configs/p167_base-fmriprep_perturb-ccs_step-structural-registration_conn-nilearn_nuisance-false.yml
@@ -289,6 +289,7 @@ nuisance_corrections:
     - false
     space: template
 pipeline_setup:
+  freesurfer_dir: /ocean/projects/med220004p/trogers1/many_pipelines/freesurfer/outputs/ABCD_all_subjects
   Amazon-AWS:
     aws_output_bucket_credentials: null
     s3_encryption: true
@@ -339,7 +340,7 @@ pipeline_setup:
     random_seed: null
   working_directory:
     path: /outputs/working
-    remove_working_dir: true
+    remove_working_dir: false
 post_processing:
   spatial_smoothing:
     fwhm:
@@ -365,7 +366,6 @@ registration_workflows:
     T1w_template: $FSLDIR/data/standard/MNI152_T1_${resolution_for_anat}.nii.gz
     overwrite_transform:
       run: false
-      using: FSL
     reg_with_skull: false
     registration:
       ANTs:
@@ -433,10 +433,9 @@ registration_workflows:
         identity_matrix: $FSLDIR/etc/flirtsch/ident.mat
         interpolation: trilinear
         ref_mask: $FSLDIR/data/standard/MNI152_T1_${resolution_for_anat}_brain_mask_dil.nii.gz
-        ref_mask_res-2: $FSLDIR/data/standard/MNI152_T1_2mm_brain_mask_dil.nii.gz
         ref_resolution: 2mm
       using:
-      - FSL
+      - ANTS
     resolution_for_anat: 2mm
     run: true
   functional_registration:
@@ -471,8 +470,6 @@ registration_workflows:
           func_reg_input_volume: 0
         input:
         - fmriprep_reference
-        reg_with_skull: false
-      input: brain
       interpolation: trilinear
       run: true
       using: FSL
@@ -573,11 +570,6 @@ surface_analysis:
     run: false
     surface_parcellation_template: /cpac_templates/Schaefer2018_200Parcels_17Networks_order.dlabel.nii
 timeseries_extraction:
-  connectivity_matrix:
-    measure:
-    - Pearson
-    using:
-    - Nilearn
   realignment: ROI_to_func
   run: true
   tse_roi_paths:

--- a/configs/p168_base-fmriprep_perturb-ccs_step-functional-masking_conn-afni_nuisance-true.yml
+++ b/configs/p168_base-fmriprep_perturb-ccs_step-functional-masking_conn-afni_nuisance-true.yml
@@ -289,6 +289,7 @@ nuisance_corrections:
     - true
     space: template
 pipeline_setup:
+  freesurfer_dir: /ocean/projects/med220004p/trogers1/many_pipelines/freesurfer/outputs/ABCD_all_subjects
   Amazon-AWS:
     aws_output_bucket_credentials: null
     s3_encryption: true
@@ -339,7 +340,7 @@ pipeline_setup:
     random_seed: null
   working_directory:
     path: /outputs/working
-    remove_working_dir: true
+    remove_working_dir: false
 post_processing:
   spatial_smoothing:
     fwhm:
@@ -433,7 +434,6 @@ registration_workflows:
         identity_matrix: $FSLDIR/etc/flirtsch/ident.mat
         interpolation: sinc
         ref_mask: null
-        ref_mask_res-2: null
         ref_resolution: 2mm
       using:
       - ANTS
@@ -471,8 +471,6 @@ registration_workflows:
           func_reg_input_volume: 0
         input:
         - fmriprep_reference
-        reg_with_skull: false
-      input: brain
       interpolation: trilinear
       run: true
       using: FSL
@@ -573,11 +571,6 @@ surface_analysis:
     run: false
     surface_parcellation_template: /cpac_templates/Schaefer2018_200Parcels_17Networks_order.dlabel.nii
 timeseries_extraction:
-  connectivity_matrix:
-    measure:
-    - Pearson
-    using:
-    - AFNI
   realignment: ROI_to_func
   run: true
   tse_roi_paths:

--- a/configs/p169_base-fmriprep_perturb-ccs_step-functional-masking_conn-afni_nuisance-false.yml
+++ b/configs/p169_base-fmriprep_perturb-ccs_step-functional-masking_conn-afni_nuisance-false.yml
@@ -289,6 +289,7 @@ nuisance_corrections:
     - false
     space: template
 pipeline_setup:
+  freesurfer_dir: /ocean/projects/med220004p/trogers1/many_pipelines/freesurfer/outputs/ABCD_all_subjects
   Amazon-AWS:
     aws_output_bucket_credentials: null
     s3_encryption: true
@@ -339,7 +340,7 @@ pipeline_setup:
     random_seed: null
   working_directory:
     path: /outputs/working
-    remove_working_dir: true
+    remove_working_dir: false
 post_processing:
   spatial_smoothing:
     fwhm:
@@ -433,7 +434,6 @@ registration_workflows:
         identity_matrix: $FSLDIR/etc/flirtsch/ident.mat
         interpolation: sinc
         ref_mask: null
-        ref_mask_res-2: null
         ref_resolution: 2mm
       using:
       - ANTS
@@ -471,8 +471,6 @@ registration_workflows:
           func_reg_input_volume: 0
         input:
         - fmriprep_reference
-        reg_with_skull: false
-      input: brain
       interpolation: trilinear
       run: true
       using: FSL
@@ -573,11 +571,6 @@ surface_analysis:
     run: false
     surface_parcellation_template: /cpac_templates/Schaefer2018_200Parcels_17Networks_order.dlabel.nii
 timeseries_extraction:
-  connectivity_matrix:
-    measure:
-    - Pearson
-    using:
-    - AFNI
   realignment: ROI_to_func
   run: true
   tse_roi_paths:

--- a/configs/p170_base-fmriprep_perturb-ccs_step-functional-masking_conn-nilearn_nuisance-true.yml
+++ b/configs/p170_base-fmriprep_perturb-ccs_step-functional-masking_conn-nilearn_nuisance-true.yml
@@ -289,6 +289,7 @@ nuisance_corrections:
     - true
     space: template
 pipeline_setup:
+  freesurfer_dir: /ocean/projects/med220004p/trogers1/many_pipelines/freesurfer/outputs/ABCD_all_subjects
   Amazon-AWS:
     aws_output_bucket_credentials: null
     s3_encryption: true
@@ -339,7 +340,7 @@ pipeline_setup:
     random_seed: null
   working_directory:
     path: /outputs/working
-    remove_working_dir: true
+    remove_working_dir: false
 post_processing:
   spatial_smoothing:
     fwhm:
@@ -433,7 +434,6 @@ registration_workflows:
         identity_matrix: $FSLDIR/etc/flirtsch/ident.mat
         interpolation: sinc
         ref_mask: null
-        ref_mask_res-2: null
         ref_resolution: 2mm
       using:
       - ANTS
@@ -471,8 +471,6 @@ registration_workflows:
           func_reg_input_volume: 0
         input:
         - fmriprep_reference
-        reg_with_skull: false
-      input: brain
       interpolation: trilinear
       run: true
       using: FSL
@@ -573,11 +571,6 @@ surface_analysis:
     run: false
     surface_parcellation_template: /cpac_templates/Schaefer2018_200Parcels_17Networks_order.dlabel.nii
 timeseries_extraction:
-  connectivity_matrix:
-    measure:
-    - Pearson
-    using:
-    - Nilearn
   realignment: ROI_to_func
   run: true
   tse_roi_paths:

--- a/configs/p171_base-fmriprep_perturb-ccs_step-functional-masking_conn-nilearn_nuisance-false.yml
+++ b/configs/p171_base-fmriprep_perturb-ccs_step-functional-masking_conn-nilearn_nuisance-false.yml
@@ -289,6 +289,7 @@ nuisance_corrections:
     - false
     space: template
 pipeline_setup:
+  freesurfer_dir: /ocean/projects/med220004p/trogers1/many_pipelines/freesurfer/outputs/ABCD_all_subjects
   Amazon-AWS:
     aws_output_bucket_credentials: null
     s3_encryption: true
@@ -339,7 +340,7 @@ pipeline_setup:
     random_seed: null
   working_directory:
     path: /outputs/working
-    remove_working_dir: true
+    remove_working_dir: false
 post_processing:
   spatial_smoothing:
     fwhm:
@@ -433,7 +434,6 @@ registration_workflows:
         identity_matrix: $FSLDIR/etc/flirtsch/ident.mat
         interpolation: sinc
         ref_mask: null
-        ref_mask_res-2: null
         ref_resolution: 2mm
       using:
       - ANTS
@@ -471,8 +471,6 @@ registration_workflows:
           func_reg_input_volume: 0
         input:
         - fmriprep_reference
-        reg_with_skull: false
-      input: brain
       interpolation: trilinear
       run: true
       using: FSL
@@ -573,11 +571,6 @@ surface_analysis:
     run: false
     surface_parcellation_template: /cpac_templates/Schaefer2018_200Parcels_17Networks_order.dlabel.nii
 timeseries_extraction:
-  connectivity_matrix:
-    measure:
-    - Pearson
-    using:
-    - Nilearn
   realignment: ROI_to_func
   run: true
   tse_roi_paths:

--- a/configs/p172_base-fmriprep_perturb-ccs_step-functional-registration_conn-afni_nuisance-true.yml
+++ b/configs/p172_base-fmriprep_perturb-ccs_step-functional-registration_conn-afni_nuisance-true.yml
@@ -289,6 +289,7 @@ nuisance_corrections:
     - true
     space: template
 pipeline_setup:
+  freesurfer_dir: /ocean/projects/med220004p/trogers1/many_pipelines/freesurfer/outputs/ABCD_all_subjects
   Amazon-AWS:
     aws_output_bucket_credentials: null
     s3_encryption: true
@@ -339,7 +340,7 @@ pipeline_setup:
     random_seed: null
   working_directory:
     path: /outputs/working
-    remove_working_dir: true
+    remove_working_dir: false
 post_processing:
   spatial_smoothing:
     fwhm:
@@ -433,7 +434,6 @@ registration_workflows:
         identity_matrix: $FSLDIR/etc/flirtsch/ident.mat
         interpolation: sinc
         ref_mask: null
-        ref_mask_res-2: null
         ref_resolution: 2mm
       using:
       - ANTS
@@ -471,8 +471,6 @@ registration_workflows:
           func_reg_input_volume: 7
         input:
         - Selected_Functional_Volume
-        reg_with_skull: false
-      input: brain
       interpolation: trilinear
       run: true
       using: FSL
@@ -573,11 +571,6 @@ surface_analysis:
     run: false
     surface_parcellation_template: /cpac_templates/Schaefer2018_200Parcels_17Networks_order.dlabel.nii
 timeseries_extraction:
-  connectivity_matrix:
-    measure:
-    - Pearson
-    using:
-    - AFNI
   realignment: ROI_to_func
   run: true
   tse_roi_paths:

--- a/configs/p173_base-fmriprep_perturb-ccs_step-functional-registration_conn-afni_nuisance-false.yml
+++ b/configs/p173_base-fmriprep_perturb-ccs_step-functional-registration_conn-afni_nuisance-false.yml
@@ -289,6 +289,7 @@ nuisance_corrections:
     - false
     space: template
 pipeline_setup:
+  freesurfer_dir: /ocean/projects/med220004p/trogers1/many_pipelines/freesurfer/outputs/ABCD_all_subjects
   Amazon-AWS:
     aws_output_bucket_credentials: null
     s3_encryption: true
@@ -339,7 +340,7 @@ pipeline_setup:
     random_seed: null
   working_directory:
     path: /outputs/working
-    remove_working_dir: true
+    remove_working_dir: false
 post_processing:
   spatial_smoothing:
     fwhm:
@@ -433,7 +434,6 @@ registration_workflows:
         identity_matrix: $FSLDIR/etc/flirtsch/ident.mat
         interpolation: sinc
         ref_mask: null
-        ref_mask_res-2: null
         ref_resolution: 2mm
       using:
       - ANTS
@@ -471,8 +471,6 @@ registration_workflows:
           func_reg_input_volume: 7
         input:
         - Selected_Functional_Volume
-        reg_with_skull: false
-      input: brain
       interpolation: trilinear
       run: true
       using: FSL
@@ -573,11 +571,6 @@ surface_analysis:
     run: false
     surface_parcellation_template: /cpac_templates/Schaefer2018_200Parcels_17Networks_order.dlabel.nii
 timeseries_extraction:
-  connectivity_matrix:
-    measure:
-    - Pearson
-    using:
-    - AFNI
   realignment: ROI_to_func
   run: true
   tse_roi_paths:

--- a/configs/p174_base-fmriprep_perturb-ccs_step-functional-registration_conn-nilearn_nuisance-true.yml
+++ b/configs/p174_base-fmriprep_perturb-ccs_step-functional-registration_conn-nilearn_nuisance-true.yml
@@ -289,6 +289,7 @@ nuisance_corrections:
     - true
     space: template
 pipeline_setup:
+  freesurfer_dir: /ocean/projects/med220004p/trogers1/many_pipelines/freesurfer/outputs/ABCD_all_subjects
   Amazon-AWS:
     aws_output_bucket_credentials: null
     s3_encryption: true
@@ -339,7 +340,7 @@ pipeline_setup:
     random_seed: null
   working_directory:
     path: /outputs/working
-    remove_working_dir: true
+    remove_working_dir: false
 post_processing:
   spatial_smoothing:
     fwhm:
@@ -433,7 +434,6 @@ registration_workflows:
         identity_matrix: $FSLDIR/etc/flirtsch/ident.mat
         interpolation: sinc
         ref_mask: null
-        ref_mask_res-2: null
         ref_resolution: 2mm
       using:
       - ANTS
@@ -471,8 +471,6 @@ registration_workflows:
           func_reg_input_volume: 7
         input:
         - Selected_Functional_Volume
-        reg_with_skull: false
-      input: brain
       interpolation: trilinear
       run: true
       using: FSL
@@ -573,11 +571,6 @@ surface_analysis:
     run: false
     surface_parcellation_template: /cpac_templates/Schaefer2018_200Parcels_17Networks_order.dlabel.nii
 timeseries_extraction:
-  connectivity_matrix:
-    measure:
-    - Pearson
-    using:
-    - Nilearn
   realignment: ROI_to_func
   run: true
   tse_roi_paths:

--- a/configs/p175_base-fmriprep_perturb-ccs_step-functional-registration_conn-nilearn_nuisance-false.yml
+++ b/configs/p175_base-fmriprep_perturb-ccs_step-functional-registration_conn-nilearn_nuisance-false.yml
@@ -289,6 +289,7 @@ nuisance_corrections:
     - false
     space: template
 pipeline_setup:
+  freesurfer_dir: /ocean/projects/med220004p/trogers1/many_pipelines/freesurfer/outputs/ABCD_all_subjects
   Amazon-AWS:
     aws_output_bucket_credentials: null
     s3_encryption: true
@@ -339,7 +340,7 @@ pipeline_setup:
     random_seed: null
   working_directory:
     path: /outputs/working
-    remove_working_dir: true
+    remove_working_dir: false
 post_processing:
   spatial_smoothing:
     fwhm:
@@ -433,7 +434,6 @@ registration_workflows:
         identity_matrix: $FSLDIR/etc/flirtsch/ident.mat
         interpolation: sinc
         ref_mask: null
-        ref_mask_res-2: null
         ref_resolution: 2mm
       using:
       - ANTS
@@ -471,8 +471,6 @@ registration_workflows:
           func_reg_input_volume: 7
         input:
         - Selected_Functional_Volume
-        reg_with_skull: false
-      input: brain
       interpolation: trilinear
       run: true
       using: FSL
@@ -573,11 +571,6 @@ surface_analysis:
     run: false
     surface_parcellation_template: /cpac_templates/Schaefer2018_200Parcels_17Networks_order.dlabel.nii
 timeseries_extraction:
-  connectivity_matrix:
-    measure:
-    - Pearson
-    using:
-    - Nilearn
   realignment: ROI_to_func
   run: true
   tse_roi_paths:

--- a/configs/p176_base-fmriprep_perturb-rbc_step-structural-masking_conn-afni_nuisance-true.yml
+++ b/configs/p176_base-fmriprep_perturb-rbc_step-structural-masking_conn-afni_nuisance-true.yml
@@ -289,6 +289,7 @@ nuisance_corrections:
     - true
     space: template
 pipeline_setup:
+  freesurfer_dir: /ocean/projects/med220004p/trogers1/many_pipelines/freesurfer/outputs/ABCD_all_subjects
   Amazon-AWS:
     aws_output_bucket_credentials: null
     s3_encryption: true
@@ -339,7 +340,7 @@ pipeline_setup:
     random_seed: null
   working_directory:
     path: /outputs/working
-    remove_working_dir: true
+    remove_working_dir: false
 post_processing:
   spatial_smoothing:
     fwhm:
@@ -433,7 +434,6 @@ registration_workflows:
         identity_matrix: $FSLDIR/etc/flirtsch/ident.mat
         interpolation: sinc
         ref_mask: null
-        ref_mask_res-2: null
         ref_resolution: 2mm
       using:
       - ANTS
@@ -471,8 +471,6 @@ registration_workflows:
           func_reg_input_volume: 0
         input:
         - fmriprep_reference
-        reg_with_skull: false
-      input: brain
       interpolation: trilinear
       run: true
       using: FSL
@@ -573,11 +571,6 @@ surface_analysis:
     run: false
     surface_parcellation_template: /cpac_templates/Schaefer2018_200Parcels_17Networks_order.dlabel.nii
 timeseries_extraction:
-  connectivity_matrix:
-    measure:
-    - Pearson
-    using:
-    - AFNI
   realignment: ROI_to_func
   run: true
   tse_roi_paths:

--- a/configs/p177_base-fmriprep_perturb-rbc_step-structural-masking_conn-afni_nuisance-false.yml
+++ b/configs/p177_base-fmriprep_perturb-rbc_step-structural-masking_conn-afni_nuisance-false.yml
@@ -289,6 +289,7 @@ nuisance_corrections:
     - false
     space: template
 pipeline_setup:
+  freesurfer_dir: /ocean/projects/med220004p/trogers1/many_pipelines/freesurfer/outputs/ABCD_all_subjects
   Amazon-AWS:
     aws_output_bucket_credentials: null
     s3_encryption: true
@@ -339,7 +340,7 @@ pipeline_setup:
     random_seed: null
   working_directory:
     path: /outputs/working
-    remove_working_dir: true
+    remove_working_dir: false
 post_processing:
   spatial_smoothing:
     fwhm:
@@ -433,7 +434,6 @@ registration_workflows:
         identity_matrix: $FSLDIR/etc/flirtsch/ident.mat
         interpolation: sinc
         ref_mask: null
-        ref_mask_res-2: null
         ref_resolution: 2mm
       using:
       - ANTS
@@ -471,8 +471,6 @@ registration_workflows:
           func_reg_input_volume: 0
         input:
         - fmriprep_reference
-        reg_with_skull: false
-      input: brain
       interpolation: trilinear
       run: true
       using: FSL
@@ -573,11 +571,6 @@ surface_analysis:
     run: false
     surface_parcellation_template: /cpac_templates/Schaefer2018_200Parcels_17Networks_order.dlabel.nii
 timeseries_extraction:
-  connectivity_matrix:
-    measure:
-    - Pearson
-    using:
-    - AFNI
   realignment: ROI_to_func
   run: true
   tse_roi_paths:

--- a/configs/p178_base-fmriprep_perturb-rbc_step-structural-masking_conn-nilearn_nuisance-true.yml
+++ b/configs/p178_base-fmriprep_perturb-rbc_step-structural-masking_conn-nilearn_nuisance-true.yml
@@ -289,6 +289,7 @@ nuisance_corrections:
     - true
     space: template
 pipeline_setup:
+  freesurfer_dir: /ocean/projects/med220004p/trogers1/many_pipelines/freesurfer/outputs/ABCD_all_subjects
   Amazon-AWS:
     aws_output_bucket_credentials: null
     s3_encryption: true
@@ -339,7 +340,7 @@ pipeline_setup:
     random_seed: null
   working_directory:
     path: /outputs/working
-    remove_working_dir: true
+    remove_working_dir: false
 post_processing:
   spatial_smoothing:
     fwhm:
@@ -433,7 +434,6 @@ registration_workflows:
         identity_matrix: $FSLDIR/etc/flirtsch/ident.mat
         interpolation: sinc
         ref_mask: null
-        ref_mask_res-2: null
         ref_resolution: 2mm
       using:
       - ANTS
@@ -471,8 +471,6 @@ registration_workflows:
           func_reg_input_volume: 0
         input:
         - fmriprep_reference
-        reg_with_skull: false
-      input: brain
       interpolation: trilinear
       run: true
       using: FSL
@@ -573,11 +571,6 @@ surface_analysis:
     run: false
     surface_parcellation_template: /cpac_templates/Schaefer2018_200Parcels_17Networks_order.dlabel.nii
 timeseries_extraction:
-  connectivity_matrix:
-    measure:
-    - Pearson
-    using:
-    - Nilearn
   realignment: ROI_to_func
   run: true
   tse_roi_paths:

--- a/configs/p179_base-fmriprep_perturb-rbc_step-structural-masking_conn-nilearn_nuisance-false.yml
+++ b/configs/p179_base-fmriprep_perturb-rbc_step-structural-masking_conn-nilearn_nuisance-false.yml
@@ -289,6 +289,7 @@ nuisance_corrections:
     - false
     space: template
 pipeline_setup:
+  freesurfer_dir: /ocean/projects/med220004p/trogers1/many_pipelines/freesurfer/outputs/ABCD_all_subjects
   Amazon-AWS:
     aws_output_bucket_credentials: null
     s3_encryption: true
@@ -339,7 +340,7 @@ pipeline_setup:
     random_seed: null
   working_directory:
     path: /outputs/working
-    remove_working_dir: true
+    remove_working_dir: false
 post_processing:
   spatial_smoothing:
     fwhm:
@@ -433,7 +434,6 @@ registration_workflows:
         identity_matrix: $FSLDIR/etc/flirtsch/ident.mat
         interpolation: sinc
         ref_mask: null
-        ref_mask_res-2: null
         ref_resolution: 2mm
       using:
       - ANTS
@@ -471,8 +471,6 @@ registration_workflows:
           func_reg_input_volume: 0
         input:
         - fmriprep_reference
-        reg_with_skull: false
-      input: brain
       interpolation: trilinear
       run: true
       using: FSL
@@ -573,11 +571,6 @@ surface_analysis:
     run: false
     surface_parcellation_template: /cpac_templates/Schaefer2018_200Parcels_17Networks_order.dlabel.nii
 timeseries_extraction:
-  connectivity_matrix:
-    measure:
-    - Pearson
-    using:
-    - Nilearn
   realignment: ROI_to_func
   run: true
   tse_roi_paths:

--- a/configs/p180_base-fmriprep_perturb-rbc_step-structural-registration_conn-afni_nuisance-true.yml
+++ b/configs/p180_base-fmriprep_perturb-rbc_step-structural-registration_conn-afni_nuisance-true.yml
@@ -289,6 +289,7 @@ nuisance_corrections:
     - true
     space: template
 pipeline_setup:
+  freesurfer_dir: /ocean/projects/med220004p/trogers1/many_pipelines/freesurfer/outputs/ABCD_all_subjects
   Amazon-AWS:
     aws_output_bucket_credentials: null
     s3_encryption: true
@@ -339,7 +340,7 @@ pipeline_setup:
     random_seed: null
   working_directory:
     path: /outputs/working
-    remove_working_dir: true
+    remove_working_dir: false
 post_processing:
   spatial_smoothing:
     fwhm:
@@ -433,7 +434,6 @@ registration_workflows:
         identity_matrix: $FSLDIR/etc/flirtsch/ident.mat
         interpolation: sinc
         ref_mask: null
-        ref_mask_res-2: null
         ref_resolution: 2mm
       using:
       - ANTS
@@ -471,8 +471,6 @@ registration_workflows:
           func_reg_input_volume: 0
         input:
         - fmriprep_reference
-        reg_with_skull: false
-      input: brain
       interpolation: trilinear
       run: true
       using: FSL
@@ -573,11 +571,6 @@ surface_analysis:
     run: false
     surface_parcellation_template: /cpac_templates/Schaefer2018_200Parcels_17Networks_order.dlabel.nii
 timeseries_extraction:
-  connectivity_matrix:
-    measure:
-    - Pearson
-    using:
-    - AFNI
   realignment: ROI_to_func
   run: true
   tse_roi_paths:

--- a/configs/p181_base-fmriprep_perturb-rbc_step-structural-registration_conn-afni_nuisance-false.yml
+++ b/configs/p181_base-fmriprep_perturb-rbc_step-structural-registration_conn-afni_nuisance-false.yml
@@ -289,6 +289,7 @@ nuisance_corrections:
     - false
     space: template
 pipeline_setup:
+  freesurfer_dir: /ocean/projects/med220004p/trogers1/many_pipelines/freesurfer/outputs/ABCD_all_subjects
   Amazon-AWS:
     aws_output_bucket_credentials: null
     s3_encryption: true
@@ -339,7 +340,7 @@ pipeline_setup:
     random_seed: null
   working_directory:
     path: /outputs/working
-    remove_working_dir: true
+    remove_working_dir: false
 post_processing:
   spatial_smoothing:
     fwhm:
@@ -433,7 +434,6 @@ registration_workflows:
         identity_matrix: $FSLDIR/etc/flirtsch/ident.mat
         interpolation: sinc
         ref_mask: null
-        ref_mask_res-2: null
         ref_resolution: 2mm
       using:
       - ANTS
@@ -471,8 +471,6 @@ registration_workflows:
           func_reg_input_volume: 0
         input:
         - fmriprep_reference
-        reg_with_skull: false
-      input: brain
       interpolation: trilinear
       run: true
       using: FSL
@@ -573,11 +571,6 @@ surface_analysis:
     run: false
     surface_parcellation_template: /cpac_templates/Schaefer2018_200Parcels_17Networks_order.dlabel.nii
 timeseries_extraction:
-  connectivity_matrix:
-    measure:
-    - Pearson
-    using:
-    - AFNI
   realignment: ROI_to_func
   run: true
   tse_roi_paths:

--- a/configs/p182_base-fmriprep_perturb-rbc_step-structural-registration_conn-nilearn_nuisance-true.yml
+++ b/configs/p182_base-fmriprep_perturb-rbc_step-structural-registration_conn-nilearn_nuisance-true.yml
@@ -289,6 +289,7 @@ nuisance_corrections:
     - true
     space: template
 pipeline_setup:
+  freesurfer_dir: /ocean/projects/med220004p/trogers1/many_pipelines/freesurfer/outputs/ABCD_all_subjects
   Amazon-AWS:
     aws_output_bucket_credentials: null
     s3_encryption: true
@@ -339,7 +340,7 @@ pipeline_setup:
     random_seed: null
   working_directory:
     path: /outputs/working
-    remove_working_dir: true
+    remove_working_dir: false
 post_processing:
   spatial_smoothing:
     fwhm:
@@ -433,7 +434,6 @@ registration_workflows:
         identity_matrix: $FSLDIR/etc/flirtsch/ident.mat
         interpolation: sinc
         ref_mask: null
-        ref_mask_res-2: null
         ref_resolution: 2mm
       using:
       - ANTS
@@ -471,8 +471,6 @@ registration_workflows:
           func_reg_input_volume: 0
         input:
         - fmriprep_reference
-        reg_with_skull: false
-      input: brain
       interpolation: trilinear
       run: true
       using: FSL
@@ -573,11 +571,6 @@ surface_analysis:
     run: false
     surface_parcellation_template: /cpac_templates/Schaefer2018_200Parcels_17Networks_order.dlabel.nii
 timeseries_extraction:
-  connectivity_matrix:
-    measure:
-    - Pearson
-    using:
-    - Nilearn
   realignment: ROI_to_func
   run: true
   tse_roi_paths:

--- a/configs/p183_base-fmriprep_perturb-rbc_step-structural-registration_conn-nilearn_nuisance-false.yml
+++ b/configs/p183_base-fmriprep_perturb-rbc_step-structural-registration_conn-nilearn_nuisance-false.yml
@@ -289,6 +289,7 @@ nuisance_corrections:
     - false
     space: template
 pipeline_setup:
+  freesurfer_dir: /ocean/projects/med220004p/trogers1/many_pipelines/freesurfer/outputs/ABCD_all_subjects
   Amazon-AWS:
     aws_output_bucket_credentials: null
     s3_encryption: true
@@ -339,7 +340,7 @@ pipeline_setup:
     random_seed: null
   working_directory:
     path: /outputs/working
-    remove_working_dir: true
+    remove_working_dir: false
 post_processing:
   spatial_smoothing:
     fwhm:
@@ -433,7 +434,6 @@ registration_workflows:
         identity_matrix: $FSLDIR/etc/flirtsch/ident.mat
         interpolation: sinc
         ref_mask: null
-        ref_mask_res-2: null
         ref_resolution: 2mm
       using:
       - ANTS
@@ -471,8 +471,6 @@ registration_workflows:
           func_reg_input_volume: 0
         input:
         - fmriprep_reference
-        reg_with_skull: false
-      input: brain
       interpolation: trilinear
       run: true
       using: FSL
@@ -573,11 +571,6 @@ surface_analysis:
     run: false
     surface_parcellation_template: /cpac_templates/Schaefer2018_200Parcels_17Networks_order.dlabel.nii
 timeseries_extraction:
-  connectivity_matrix:
-    measure:
-    - Pearson
-    using:
-    - Nilearn
   realignment: ROI_to_func
   run: true
   tse_roi_paths:

--- a/configs/p184_base-fmriprep_perturb-rbc_step-functional-masking_conn-afni_nuisance-true.yml
+++ b/configs/p184_base-fmriprep_perturb-rbc_step-functional-masking_conn-afni_nuisance-true.yml
@@ -289,6 +289,7 @@ nuisance_corrections:
     - true
     space: template
 pipeline_setup:
+  freesurfer_dir: /ocean/projects/med220004p/trogers1/many_pipelines/freesurfer/outputs/ABCD_all_subjects
   Amazon-AWS:
     aws_output_bucket_credentials: null
     s3_encryption: true
@@ -339,7 +340,7 @@ pipeline_setup:
     random_seed: null
   working_directory:
     path: /outputs/working
-    remove_working_dir: true
+    remove_working_dir: false
 post_processing:
   spatial_smoothing:
     fwhm:
@@ -433,7 +434,6 @@ registration_workflows:
         identity_matrix: $FSLDIR/etc/flirtsch/ident.mat
         interpolation: sinc
         ref_mask: null
-        ref_mask_res-2: null
         ref_resolution: 2mm
       using:
       - ANTS
@@ -471,8 +471,6 @@ registration_workflows:
           func_reg_input_volume: 0
         input:
         - fmriprep_reference
-        reg_with_skull: false
-      input: brain
       interpolation: trilinear
       run: true
       using: FSL
@@ -573,11 +571,6 @@ surface_analysis:
     run: false
     surface_parcellation_template: /cpac_templates/Schaefer2018_200Parcels_17Networks_order.dlabel.nii
 timeseries_extraction:
-  connectivity_matrix:
-    measure:
-    - Pearson
-    using:
-    - AFNI
   realignment: ROI_to_func
   run: true
   tse_roi_paths:

--- a/configs/p185_base-fmriprep_perturb-rbc_step-functional-masking_conn-afni_nuisance-false.yml
+++ b/configs/p185_base-fmriprep_perturb-rbc_step-functional-masking_conn-afni_nuisance-false.yml
@@ -289,6 +289,7 @@ nuisance_corrections:
     - false
     space: template
 pipeline_setup:
+  freesurfer_dir: /ocean/projects/med220004p/trogers1/many_pipelines/freesurfer/outputs/ABCD_all_subjects
   Amazon-AWS:
     aws_output_bucket_credentials: null
     s3_encryption: true
@@ -339,7 +340,7 @@ pipeline_setup:
     random_seed: null
   working_directory:
     path: /outputs/working
-    remove_working_dir: true
+    remove_working_dir: false
 post_processing:
   spatial_smoothing:
     fwhm:
@@ -433,7 +434,6 @@ registration_workflows:
         identity_matrix: $FSLDIR/etc/flirtsch/ident.mat
         interpolation: sinc
         ref_mask: null
-        ref_mask_res-2: null
         ref_resolution: 2mm
       using:
       - ANTS
@@ -471,8 +471,6 @@ registration_workflows:
           func_reg_input_volume: 0
         input:
         - fmriprep_reference
-        reg_with_skull: false
-      input: brain
       interpolation: trilinear
       run: true
       using: FSL
@@ -573,11 +571,6 @@ surface_analysis:
     run: false
     surface_parcellation_template: /cpac_templates/Schaefer2018_200Parcels_17Networks_order.dlabel.nii
 timeseries_extraction:
-  connectivity_matrix:
-    measure:
-    - Pearson
-    using:
-    - AFNI
   realignment: ROI_to_func
   run: true
   tse_roi_paths:

--- a/configs/p186_base-fmriprep_perturb-rbc_step-functional-masking_conn-nilearn_nuisance-true.yml
+++ b/configs/p186_base-fmriprep_perturb-rbc_step-functional-masking_conn-nilearn_nuisance-true.yml
@@ -289,6 +289,7 @@ nuisance_corrections:
     - true
     space: template
 pipeline_setup:
+  freesurfer_dir: /ocean/projects/med220004p/trogers1/many_pipelines/freesurfer/outputs/ABCD_all_subjects
   Amazon-AWS:
     aws_output_bucket_credentials: null
     s3_encryption: true
@@ -339,7 +340,7 @@ pipeline_setup:
     random_seed: null
   working_directory:
     path: /outputs/working
-    remove_working_dir: true
+    remove_working_dir: false
 post_processing:
   spatial_smoothing:
     fwhm:
@@ -433,7 +434,6 @@ registration_workflows:
         identity_matrix: $FSLDIR/etc/flirtsch/ident.mat
         interpolation: sinc
         ref_mask: null
-        ref_mask_res-2: null
         ref_resolution: 2mm
       using:
       - ANTS
@@ -471,8 +471,6 @@ registration_workflows:
           func_reg_input_volume: 0
         input:
         - fmriprep_reference
-        reg_with_skull: false
-      input: brain
       interpolation: trilinear
       run: true
       using: FSL
@@ -573,11 +571,6 @@ surface_analysis:
     run: false
     surface_parcellation_template: /cpac_templates/Schaefer2018_200Parcels_17Networks_order.dlabel.nii
 timeseries_extraction:
-  connectivity_matrix:
-    measure:
-    - Pearson
-    using:
-    - Nilearn
   realignment: ROI_to_func
   run: true
   tse_roi_paths:

--- a/configs/p187_base-fmriprep_perturb-rbc_step-functional-masking_conn-nilearn_nuisance-false.yml
+++ b/configs/p187_base-fmriprep_perturb-rbc_step-functional-masking_conn-nilearn_nuisance-false.yml
@@ -289,6 +289,7 @@ nuisance_corrections:
     - false
     space: template
 pipeline_setup:
+  freesurfer_dir: /ocean/projects/med220004p/trogers1/many_pipelines/freesurfer/outputs/ABCD_all_subjects
   Amazon-AWS:
     aws_output_bucket_credentials: null
     s3_encryption: true
@@ -339,7 +340,7 @@ pipeline_setup:
     random_seed: null
   working_directory:
     path: /outputs/working
-    remove_working_dir: true
+    remove_working_dir: false
 post_processing:
   spatial_smoothing:
     fwhm:
@@ -433,7 +434,6 @@ registration_workflows:
         identity_matrix: $FSLDIR/etc/flirtsch/ident.mat
         interpolation: sinc
         ref_mask: null
-        ref_mask_res-2: null
         ref_resolution: 2mm
       using:
       - ANTS
@@ -471,8 +471,6 @@ registration_workflows:
           func_reg_input_volume: 0
         input:
         - fmriprep_reference
-        reg_with_skull: false
-      input: brain
       interpolation: trilinear
       run: true
       using: FSL
@@ -573,11 +571,6 @@ surface_analysis:
     run: false
     surface_parcellation_template: /cpac_templates/Schaefer2018_200Parcels_17Networks_order.dlabel.nii
 timeseries_extraction:
-  connectivity_matrix:
-    measure:
-    - Pearson
-    using:
-    - Nilearn
   realignment: ROI_to_func
   run: true
   tse_roi_paths:

--- a/configs/p188_base-fmriprep_perturb-rbc_step-functional-registration_conn-afni_nuisance-true.yml
+++ b/configs/p188_base-fmriprep_perturb-rbc_step-functional-registration_conn-afni_nuisance-true.yml
@@ -289,6 +289,7 @@ nuisance_corrections:
     - true
     space: template
 pipeline_setup:
+  freesurfer_dir: /ocean/projects/med220004p/trogers1/many_pipelines/freesurfer/outputs/ABCD_all_subjects
   Amazon-AWS:
     aws_output_bucket_credentials: null
     s3_encryption: true
@@ -339,7 +340,7 @@ pipeline_setup:
     random_seed: null
   working_directory:
     path: /outputs/working
-    remove_working_dir: true
+    remove_working_dir: false
 post_processing:
   spatial_smoothing:
     fwhm:
@@ -433,7 +434,6 @@ registration_workflows:
         identity_matrix: $FSLDIR/etc/flirtsch/ident.mat
         interpolation: sinc
         ref_mask: null
-        ref_mask_res-2: null
         ref_resolution: 2mm
       using:
       - ANTS
@@ -470,9 +470,7 @@ registration_workflows:
         Selected Functional Volume:
           func_reg_input_volume: 0
         input:
-        - fmriprep_reference
-        reg_with_skull: false
-      input: brain
+        - fmriprep_referencess
       interpolation: trilinear
       run: true
       using: FSL
@@ -573,11 +571,6 @@ surface_analysis:
     run: false
     surface_parcellation_template: /cpac_templates/Schaefer2018_200Parcels_17Networks_order.dlabel.nii
 timeseries_extraction:
-  connectivity_matrix:
-    measure:
-    - Pearson
-    using:
-    - AFNI
   realignment: ROI_to_func
   run: true
   tse_roi_paths:

--- a/configs/p189_base-fmriprep_perturb-rbc_step-functional-registration_conn-afni_nuisance-false.yml
+++ b/configs/p189_base-fmriprep_perturb-rbc_step-functional-registration_conn-afni_nuisance-false.yml
@@ -289,6 +289,7 @@ nuisance_corrections:
     - false
     space: template
 pipeline_setup:
+  freesurfer_dir: /ocean/projects/med220004p/trogers1/many_pipelines/freesurfer/outputs/ABCD_all_subjects
   Amazon-AWS:
     aws_output_bucket_credentials: null
     s3_encryption: true
@@ -339,7 +340,7 @@ pipeline_setup:
     random_seed: null
   working_directory:
     path: /outputs/working
-    remove_working_dir: true
+    remove_working_dir: false
 post_processing:
   spatial_smoothing:
     fwhm:
@@ -433,7 +434,6 @@ registration_workflows:
         identity_matrix: $FSLDIR/etc/flirtsch/ident.mat
         interpolation: sinc
         ref_mask: null
-        ref_mask_res-2: null
         ref_resolution: 2mm
       using:
       - ANTS
@@ -471,8 +471,6 @@ registration_workflows:
           func_reg_input_volume: 0
         input:
         - fmriprep_reference
-        reg_with_skull: false
-      input: brain
       interpolation: trilinear
       run: true
       using: FSL
@@ -573,11 +571,6 @@ surface_analysis:
     run: false
     surface_parcellation_template: /cpac_templates/Schaefer2018_200Parcels_17Networks_order.dlabel.nii
 timeseries_extraction:
-  connectivity_matrix:
-    measure:
-    - Pearson
-    using:
-    - AFNI
   realignment: ROI_to_func
   run: true
   tse_roi_paths:

--- a/configs/p190_base-fmriprep_perturb-rbc_step-functional-registration_conn-nilearn_nuisance-true.yml
+++ b/configs/p190_base-fmriprep_perturb-rbc_step-functional-registration_conn-nilearn_nuisance-true.yml
@@ -289,6 +289,7 @@ nuisance_corrections:
     - true
     space: template
 pipeline_setup:
+  freesurfer_dir: /ocean/projects/med220004p/trogers1/many_pipelines/freesurfer/outputs/ABCD_all_subjects
   Amazon-AWS:
     aws_output_bucket_credentials: null
     s3_encryption: true
@@ -339,7 +340,7 @@ pipeline_setup:
     random_seed: null
   working_directory:
     path: /outputs/working
-    remove_working_dir: true
+    remove_working_dir: false
 post_processing:
   spatial_smoothing:
     fwhm:
@@ -433,7 +434,6 @@ registration_workflows:
         identity_matrix: $FSLDIR/etc/flirtsch/ident.mat
         interpolation: sinc
         ref_mask: null
-        ref_mask_res-2: null
         ref_resolution: 2mm
       using:
       - ANTS
@@ -471,8 +471,6 @@ registration_workflows:
           func_reg_input_volume: 0
         input:
         - fmriprep_reference
-        reg_with_skull: false
-      input: brain
       interpolation: trilinear
       run: true
       using: FSL
@@ -573,11 +571,6 @@ surface_analysis:
     run: false
     surface_parcellation_template: /cpac_templates/Schaefer2018_200Parcels_17Networks_order.dlabel.nii
 timeseries_extraction:
-  connectivity_matrix:
-    measure:
-    - Pearson
-    using:
-    - Nilearn
   realignment: ROI_to_func
   run: true
   tse_roi_paths:

--- a/configs/p191_base-fmriprep_perturb-rbc_step-functional-registration_conn-nilearn_nuisance-false.yml
+++ b/configs/p191_base-fmriprep_perturb-rbc_step-functional-registration_conn-nilearn_nuisance-false.yml
@@ -289,6 +289,7 @@ nuisance_corrections:
     - false
     space: template
 pipeline_setup:
+  freesurfer_dir: /ocean/projects/med220004p/trogers1/many_pipelines/freesurfer/outputs/ABCD_all_subjects
   Amazon-AWS:
     aws_output_bucket_credentials: null
     s3_encryption: true
@@ -339,7 +340,7 @@ pipeline_setup:
     random_seed: null
   working_directory:
     path: /outputs/working
-    remove_working_dir: true
+    remove_working_dir: false
 post_processing:
   spatial_smoothing:
     fwhm:
@@ -433,7 +434,6 @@ registration_workflows:
         identity_matrix: $FSLDIR/etc/flirtsch/ident.mat
         interpolation: sinc
         ref_mask: null
-        ref_mask_res-2: null
         ref_resolution: 2mm
       using:
       - ANTS
@@ -471,8 +471,6 @@ registration_workflows:
           func_reg_input_volume: 0
         input:
         - fmriprep_reference
-        reg_with_skull: false
-      input: brain
       interpolation: trilinear
       run: true
       using: FSL
@@ -573,11 +571,6 @@ surface_analysis:
     run: false
     surface_parcellation_template: /cpac_templates/Schaefer2018_200Parcels_17Networks_order.dlabel.nii
 timeseries_extraction:
-  connectivity_matrix:
-    measure:
-    - Pearson
-    using:
-    - Nilearn
   realignment: ROI_to_func
   run: true
   tse_roi_paths:


### PR DESCRIPTION
This PR compares the current version of the many_pipelines configs with the original [gen192](https://github.com/childmindresearch/gen192/releases/download/dev/gen192_nofork.zip) versions.  These configs are consistent with the most recent dev version of C-PAC.

Note that p036, p037, p038, p039 are not currently functional to completion (get stuck on a missing resource error: `from-T1w_to-ACPC_mode-image_desc-aff2rig_xfm`).

As of 4/17, @tamsinrogers & @nx10 have updated the config generation script to handle these changes based on combinations of the pipeline ids up to p116.

Refer to [Pipeline Config Notes + Edits doc](https://docs.google.com/document/d/1WyARU5wkkAd9VrT24Tc7xJWJf7CIGO29PY0IM4tdGgQ/edit?tab=t.0#bookmark=id.srct9da60j96) for more detail.